### PR TITLE
Fix SSH / SFTP confusion

### DIFF
--- a/package/yast2-kdump.changes
+++ b/package/yast2-kdump.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon May 25 21:31:15 UTC 2015 - ptesarik@suse.cz
+
+- Add 'sftp' dump target, which is distinct from 'ssh' in kdump
+  version 0.8.12 or newer (bsc#868704).
+
+-------------------------------------------------------------------
 Mon May 25 20:23:55 UTC 2015 - ptesarik@suse.cz
 
 - Don't mention 'scp' in the SSH dump target, as the SCP protocol

--- a/package/yast2-kdump.changes
+++ b/package/yast2-kdump.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon May 25 20:23:55 UTC 2015 - ptesarik@suse.cz
+
+- Don't mention 'scp' in the SSH dump target, as the SCP protocol
+  has never been used to transfer dumps (bsc#868704).
+
+-------------------------------------------------------------------
 Fri Feb  6 13:06:53 UTC 2015 - ancor@suse.com
 
 - The unit tests are now compatible with RSpec 3 (bnc#916364)

--- a/src/clients/kdump.rb
+++ b/src/clients/kdump.rb
@@ -106,6 +106,7 @@ module Yast
               "dumptarget taget=file dir=/var/log/dump",
               "dumptarget taget=ftp server=name_server port=21 dir=/var/log/dump user=user_name pass=path_to_file_with_password",
               "dumptarget taget=ssh server=name_server port=22 dir=/var/log/dump user=user_name",
+              "dumptarget taget=sftp server=name_server port=22 dir=/var/log/dump user=user_name",
               "dumptarget taget=nfs server=name_server dir=/var/log/dump",
               "dumptarget taget=cifs server=name_server share=share_name dir=/var/log/dump user=user_name pass=path_to_file_with_password"
             ]
@@ -252,7 +253,7 @@ module Yast
             "type" => "string",
             # TRANSLATORS: CommandLine help
             "help" => _(
-              "Dump target includes type of target from: file (local filesystem), ftp, ssh, nfs, cifs"
+              "Dump target includes type of target from: file (local filesystem), ftp, ssh, sftp, nfs, cifs"
             )
           },
           "server"      => {
@@ -509,8 +510,8 @@ module Yast
             )
           end 
 
-          #ssh connection
-        elsif Ops.get(@KDUMP_SAVE_TARGET, "target") == "ssh"
+          #ssh/sftp connection
+        elsif ["ssh", "sftp"].include?(@KDUMP_SAVE_TARGET["target"])
           #TRANSLATORS: CommandLine printed text
           CommandLine.Print(
             Builtins.sformat(
@@ -901,8 +902,8 @@ module Yast
               return false if password == nil || password == ""
               Ops.set(@KDUMP_SAVE_TARGET, "password", password)
             end
-          when "ssh"
-            Ops.set(@KDUMP_SAVE_TARGET, "target", "ssh")
+          when "ssh", "sftp"
+            @KDUMP_SAVE_TARGET["target"] = target
 
             if Ops.get(options, "server") != nil
               Ops.set(

--- a/src/include/kdump/dialogs.rb
+++ b/src/include/kdump/dialogs.rb
@@ -221,6 +221,7 @@ module Yast
             ["local_filesystem", _("Local Directory")],
             ["ftp", _("FTP")],
             ["ssh", _("SSH")],
+            ["sftp", _("SFTP")],
             ["nfs", _("NFS")],
             ["cifs", _("CIFS (SMB)")]
           ],

--- a/src/include/kdump/dialogs.rb
+++ b/src/include/kdump/dialogs.rb
@@ -220,7 +220,7 @@ module Yast
           "items"             => [
             ["local_filesystem", _("Local Directory")],
             ["ftp", _("FTP")],
-            ["ssh", _("SSH (scp)")],
+            ["ssh", _("SSH")],
             ["nfs", _("NFS")],
             ["cifs", _("CIFS (SMB)")]
           ],

--- a/src/include/kdump/helps.rb
+++ b/src/include/kdump/helps.rb
@@ -68,18 +68,18 @@ module Yast
             "    <i>Compressed Format</i> - Compress dump data by each page with gzip.<br>\n" +
             "    <i>LZO Compressed Format</i> - Slightly bigger files but much faster.<br>\n</p>"
         ),
-        # Dump Format - RadioButtons  1/6
+        # Dump Format - RadioButtons  1/7
         "TargetKdump"            => _(
           "<p><b>Saving Target for Kdump Image</b><br>\n    The target for saving kdump images. Select type of target for saving dumps.<br></p>"
         ) +
-          # Dump Format - RadioButtons  2/6
+          # Dump Format - RadioButtons  2/7
           _(
             "<p><b>Local Filestem</b> - Save kdump image in the local filesystem.\n" +
               "    <i>Directory for Saving Dumps</i> - The path for saving kdump images.\n" +
               "    Selecting directory for saving kdump images via dialog by pressing <i>Browse</i>\n" +
               "    <br></p>"
           ) +
-          # Dump Format - RadioButtons  3/6
+          # Dump Format - RadioButtons  3/7
           _(
             "<p><b>FTP</b> - Save kdump image via FTP.\n" +
               "    <i>Server Name</i> - The name of ftp server.\n" +
@@ -88,22 +88,31 @@ module Yast
               "    <i>Enable Anonymous FTP</i> enables anonymous connection to server.\n" +
               "    <i>User Name</i> for ftp connection. <i>Password</i> for ftp connection.<br></p>"
           ) +
-          # Dump Format - RadioButtons  4/6
+          # Dump Format - RadioButtons  4/7
           _(
-            "<p><b>SSH</b> - Save kdump image via SSH.\n" +
+            "<p><b>SSH</b> - Save kdump image via SSH and 'dd' on target machine.\n" +
               "    <i>Server Name</i> - The name of server.\n" +
               "    <i>Port</i> - The port number for connection.\n" +
               "    <i>Directory on Server</i> - The path for saving kdump images.\n" +
               "    <i>User Name</i> for SSH connection.  \n" +
               "    <i>Password</i> for SSH connection.<br></p>\n"
           ) +
-          # Dump Format - RadioButtons  5/6
+          # Dump Format - RadioButtons  5/7
+          _(
+            "<p><b>SFTP</b> - Save kdump image via SFTP.\n" +
+              "    <i>Server Name</i> - The name of server.\n" +
+              "    <i>Port</i> - The port number for connection.\n" +
+              "    <i>Directory on Server</i> - The path for saving kdump images.\n" +
+              "    <i>User Name</i> for SSH connection.  \n" +
+              "    <i>Password</i> for SSH connection.<br></p>\n"
+          ) +
+          # Dump Format - RadioButtons  6/7
           _(
             "<p><b>NFS</b> - Save kdump image on NFS.\n" +
               "    <i>Server Name</i> - The name of nfs server.\n" +
               "    <i>Directory on Server</i> - The path for saving kdump images.<br></p>"
           ) +
-          # Dump Format - RadioButtons  6/6
+          # Dump Format - RadioButtons  7/7
           _(
             "<p><b>CIFS</b> - Save kdump image via CIFS.\n" +
               "    <i>Server Name</i> - The name of server.\n" +

--- a/src/include/kdump/uifunctions.rb
+++ b/src/include/kdump/uifunctions.rb
@@ -140,7 +140,7 @@ module Yast
 
       @ssh = VBox(
         Frame(
-          _("SSH (scp)"),
+          _("SSH"),
           HBox(
             HSpacing(1),
             VBox(

--- a/src/include/kdump/uifunctions.rb
+++ b/src/include/kdump/uifunctions.rb
@@ -140,7 +140,7 @@ module Yast
 
       @ssh = VBox(
         Frame(
-          _("SSH"),
+          _("SSH / SFTP"),
           HBox(
             HSpacing(1),
             VBox(
@@ -290,9 +290,7 @@ module Yast
             "dir",
             Builtins.substring(parse_target, pos)
           )
-        elsif Ops.get(@KDUMP_SAVE_TARGET, "target") == "ftp" ||
-            Ops.get(@KDUMP_SAVE_TARGET, "target") == "cifs" ||
-            Ops.get(@KDUMP_SAVE_TARGET, "target") == "ssh"
+        elsif ["ftp", "cifs", "ssh", "sftp"].include?(@KDUMP_SAVE_TARGET["target"])
           pos = Builtins.search(parse_target, "@")
 
           if pos != nil
@@ -320,8 +318,7 @@ module Yast
             parse_target = Builtins.substring(parse_target, Ops.add(pos, 1))
           end
           # only ftp & ssh
-          if Ops.get(@KDUMP_SAVE_TARGET, "target") == "ftp" ||
-              Ops.get(@KDUMP_SAVE_TARGET, "target") == "ssh"
+          if ["ftp", "ssh", "sftp"].include?(@KDUMP_SAVE_TARGET["target"])
             pos1 = Builtins.search(parse_target, ":")
             pos = Builtins.search(parse_target, "/")
 
@@ -449,8 +446,8 @@ module Yast
         end 
 
         # ssh
-      elsif Ops.get(@KDUMP_SAVE_TARGET, "target") == "ssh"
-        result = "ssh://"
+      elsif ["ssh", "sftp"].include?(@KDUMP_SAVE_TARGET["target"])
+        result = @KDUMP_SAVE_TARGET["target"] + "://"
 
         if Ops.get(@KDUMP_SAVE_TARGET, "user_name") != "" &&
             Ops.get(@KDUMP_SAVE_TARGET, "password") == ""
@@ -570,10 +567,9 @@ module Yast
           Ops.get(@KDUMP_SAVE_TARGET, "server")
         )
         UI.ChangeWidget(Id("dir"), :Value, Ops.get(@KDUMP_SAVE_TARGET, "dir"))
-      elsif Ops.get(@KDUMP_SAVE_TARGET, "target") == "ssh"
+      elsif ["ssh", "sftp"].include?(@KDUMP_SAVE_TARGET["target"])
         UI.ReplaceWidget(Id("Targets"), @ssh)
-        #UI::ChangeWidget(`id ("ssh"), `Value, true);
-        UI.ChangeWidget(Id("TargetKdump"), :Value, "ssh")
+        UI.ChangeWidget(Id("TargetKdump"), :Value, @KDUMP_SAVE_TARGET["target"])
         if Ops.get(@KDUMP_SAVE_TARGET, "port") != ""
           UI.ChangeWidget(
             Id("port"),
@@ -688,7 +684,7 @@ module Yast
             return false
           end
         end
-      elsif radiobut == "ssh" || radiobut == "nfs"
+      elsif ["ssh", "sftp", "nfs"].include?(radiobut)
         value = Builtins.tostring(UI.QueryWidget(Id("server"), :Value))
 
         if value == nil || value == ""
@@ -825,7 +821,7 @@ module Yast
             Ops.get(@KDUMP_SAVE_TARGET, "password")
           )
         end
-      elsif radiobut == "ssh"
+      elsif ["ssh", "sftp"].include?(radiobut)
         UI.ReplaceWidget(Id("Targets"), @ssh)
 
         if Ops.get(@KDUMP_SAVE_TARGET, "port") != ""
@@ -946,8 +942,8 @@ module Yast
         else
           Ops.set(@KDUMP_SAVE_TARGET, "dir", "")
         end
-      elsif radiobut == "ssh"
-        Ops.set(@KDUMP_SAVE_TARGET, "target", "ssh")
+      elsif ["ssh", "sftp"].include?(radiobut)
+        @KDUMP_SAVE_TARGET["target"] = radiobut
 
         #server
         value = Builtins.tostring(UI.QueryWidget(Id("server"), :Value))

--- a/src/include/kdump/uifunctions.rb
+++ b/src/include/kdump/uifunctions.rb
@@ -768,8 +768,8 @@ module Yast
       event_name = Ops.get(event, "ID")
       #StoreTargetKdump ( key, event);
       StoreTargetKdumpHandle(@type)
-      radiobutton = Builtins.tostring(UI.QueryWidget(Id("TargetKdump"), :Value))
-      @type = radiobutton
+      radiobut = Builtins.tostring(UI.QueryWidget(Id("TargetKdump"), :Value))
+      @type = radiobut
 
       if event_name == "anonymous"
         value = Convert.to_boolean(UI.QueryWidget(Id("anonymous"), :Value))
@@ -784,7 +784,7 @@ module Yast
           UI.ChangeWidget(Id("user_name"), :Enabled, true)
           UI.ChangeWidget(Id("password"), :Enabled, true)
         end
-      elsif radiobutton == "local_filesystem"
+      elsif radiobut == "local_filesystem"
         UI.ReplaceWidget(Id("Targets"), @local_filesystem)
         @set_network = false
         UI.ChangeWidget(Id("dir"), :Value, Ops.get(@KDUMP_SAVE_TARGET, "dir"))
@@ -795,7 +795,7 @@ module Yast
           )
           UI.ChangeWidget(Id("dir"), :Value, dir)
         end
-      elsif radiobutton == "ftp"
+      elsif radiobut == "ftp"
         UI.ReplaceWidget(Id("Targets"), @ftp)
 
         if Ops.get(@KDUMP_SAVE_TARGET, "port") != ""
@@ -825,7 +825,7 @@ module Yast
             Ops.get(@KDUMP_SAVE_TARGET, "password")
           )
         end
-      elsif radiobutton == "ssh"
+      elsif radiobut == "ssh"
         UI.ReplaceWidget(Id("Targets"), @ssh)
 
         if Ops.get(@KDUMP_SAVE_TARGET, "port") != ""
@@ -838,7 +838,7 @@ module Yast
         Builtins.foreach(["server", "user_name", "dir", "password"]) do |key2|
           UI.ChangeWidget(Id(key2), :Value, Ops.get(@KDUMP_SAVE_TARGET, key2))
         end
-      elsif radiobutton == "nfs"
+      elsif radiobut == "nfs"
         UI.ReplaceWidget(Id("Targets"), @nfs)
         UI.ChangeWidget(
           Id("server"),
@@ -846,7 +846,7 @@ module Yast
           Ops.get(@KDUMP_SAVE_TARGET, "server")
         )
         UI.ChangeWidget(Id("dir"), :Value, Ops.get(@KDUMP_SAVE_TARGET, "dir"))
-      elsif radiobutton == "cifs"
+      elsif radiobut == "cifs"
         UI.ReplaceWidget(Id("Targets"), @cifs)
         Builtins.foreach(["server", "dir", "share", "user_name", "password"]) do |key2|
           UI.ChangeWidget(Id(key2), :Value, Ops.get(@KDUMP_SAVE_TARGET, key2))


### PR DESCRIPTION
Recent versions of kdump recognize both ssh:// and sftp:// target URLs and treat them differently. Reflect this change in the UI.