### PR TITLE
Report warning if space for dump on disk is smaller than requested

### DIFF
--- a/package/yast2-kdump.changes
+++ b/package/yast2-kdump.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jun 17 10:26:31 CEST 2015 - locilka@suse.com
+
+- Warn user in installation proposal if space available on disk
+  is smaller than RAM size + 4 GB (FATE #317488)
+- 3.1.23
+
+-------------------------------------------------------------------
 Mon May 25 21:31:15 UTC 2015 - ptesarik@suse.cz
 
 - Add 'sftp' dump target, which is distinct from 'ssh' in kdump

--- a/package/yast2-kdump.spec
+++ b/package/yast2-kdump.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-kdump
-Version:        3.1.22
+Version:        3.1.23
 Release:        0
 Summary:        Configuration of kdump
 License:        GPL-2.0

--- a/package/yast2-kdump.spec
+++ b/package/yast2-kdump.spec
@@ -40,6 +40,8 @@ Requires:       yast2
 Requires:       yast2-bootloader >= 3.1.35
 Requires:       yast2-ruby-bindings >= 1.0.0
 Requires:       yast2-storage
+# SpaceCalculation.GetPartitionInfo
+Requires:       yast2-packager
 Recommends:     makedumpfile
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 %ifarch aarch64

--- a/src/clients/kdump_proposal.rb
+++ b/src/clients/kdump_proposal.rb
@@ -47,7 +47,10 @@ module Yast
           # FATE#317488 When expectation at the end of proposal does not match
           # the value, this proposal will be called again
           "trigger"      => {
-            "expect"     => Yast::FunRef.new(Yast::Kdump.method(:free_space_for_dump_b), "integer ()"),
+            "expect"     => {
+              "class"  => "Yast::Kdump",
+              "method" => "free_space_for_dump_b",
+            },
             "value"      => Yast::Kdump.free_space_for_dump_b
           }
         }

--- a/src/clients/kdump_proposal.rb
+++ b/src/clients/kdump_proposal.rb
@@ -47,18 +47,12 @@ module Yast
           # FATE#317488 When expectation at the end of proposal does not match
           # the value, this proposal will be called again
           "trigger"      => {
-            "expect"     => "
-              Yast.import \"Kdump\"
-              Yast::Kdump.free_space_for_dump
-            ",
-            "value"      => Yast::Kdump.free_space_for_dump
+            "expect"     => Yast::FunRef.new(Yast::Kdump.method(:free_space_for_dump_b), "integer ()"),
+            "value"      => Yast::Kdump.free_space_for_dump_b
           }
         }
 
-        warning = Kdump.proposal_warnig
-        unless warning.empty?
-          @ret.merge!(warning)
-        end
+        @ret.merge!(Kdump.proposal_warning)
       elsif @func == "AskUser"
         @has_next = Ops.get_boolean(@param, "has_next", false)
         @settings = Kdump.Export

--- a/src/clients/kdump_proposal.rb
+++ b/src/clients/kdump_proposal.rb
@@ -41,7 +41,24 @@ module Yast
 
       if @func == "MakeProposal"
         Kdump.Propose
-        @ret = { "raw_proposal" => Kdump.Summary }
+
+        @ret = {
+          "raw_proposal" => Kdump.Summary,
+          # FATE#317488 When expectation at the end of proposal does not match
+          # the value, this proposal will be called again
+          "trigger"      => {
+            "expect"     => "
+              Yast.import \"Kdump\"
+              Yast::Kdump.free_space_for_dump
+            ",
+            "value"      => Yast::Kdump.free_space_for_dump
+          }
+        }
+
+        warning = Kdump.proposal_warnig
+        unless warning.empty?
+          @ret.merge!(warning)
+        end
       elsif @func == "AskUser"
         @has_next = Ops.get_boolean(@param, "has_next", false)
         @settings = Kdump.Export

--- a/src/modules/Kdump.rb
+++ b/src/modules/Kdump.rb
@@ -960,21 +960,7 @@ module Yast
 
       warning = {}
 
-      # Smaller differences are not possible to show with quite small precision
-      # in human-readable size formatting
-      if (requested_space * 0.99) < free_space && free_space < requested_space
-        warning = {
-          "warning_level" => :warning,
-          # TRANSLATORS: warning message in installation proposal,
-          # do not translate %{requested} and %{missing} - they are replaced with actual sizes later
-          "warning"       => "<ul><li>" + _(
-            "Warning! There might not be enough free space. " +
-            "%{required} required, but additional %{missing} free are missing.") % {
-            required: String.FormatSizeWithPrecision(requested_space, 2, true),
-            missing: String.FormatSizeWithPrecision((requested_space - free_space), 2, true)
-          } + "</li></ul>"
-        }
-      elsif free_space < requested_space
+      if free_space < requested_space
         warning = {
           "warning_level" => :warning,
           # TRANSLATORS: warning message in installation proposal,

--- a/src/modules/Kdump.rb
+++ b/src/modules/Kdump.rb
@@ -1099,9 +1099,7 @@ private
     # Returns unified directory name with leading and ending "/"
     # for exact matching
     def format_dirname(dirname)
-      dirname = deep_copy(dirname)
-      dirname = "/" << dirname << "/"
-      dirname.gsub(/\/+/, "/")
+      "/#{dirname}/".gsub(/\/+/, "/")
     end
 
     publish :function => :GetModified, :type => "boolean ()"

--- a/test/kdump_test.rb
+++ b/test/kdump_test.rb
@@ -3,6 +3,7 @@
 require_relative "./test_helper"
 
 Yast.import "Kdump"
+Yast.import "SpaceCalculation"
 
 describe Yast::Kdump do
   # allocated_memory is a string   in megabytes
@@ -36,6 +37,102 @@ describe Yast::Kdump do
           Yast::Kdump.ProposeAllocatedMemory
           expect(Yast::Kdump.allocated_memory.to_i).to be > 0
         end
+      end
+    end
+  end
+
+  let(:partition_info) {[
+     {"free"=>389318, "name"=>"/", "used"=>1487222},
+     {"free"=>1974697, "name"=>"usr", "used"=>4227733},
+     {"free"=>2974697, "name"=>"/var", "used"=>4227733},
+     # this is the matching partition entry
+     {"free"=>8974697, "name"=>"var/crash", "used"=>16},
+     {"free"=>397697, "name"=>"var/crash/not-this", "used"=>455}
+  ]}
+
+  describe "#free_space_for_dump" do
+    before do
+      allow(Yast::SpaceCalculation).to receive(:GetPartitionInfo).and_return(partition_info)
+      Yast::Kdump.KDUMP_SETTINGS["KDUMP_SAVEDIR"] = "file:///var/crash"
+    end
+
+    context "when dump location is local" do
+      it "returns space on disk in bytes available for kernel dump" do
+        # partition info counts in kB, we us bytes
+        expect(Yast::Kdump.free_space_for_dump).to eq(8974697 * 1024)
+      end
+    end
+
+    context "when dump location is not local" do
+      it "returns 'nil'" do
+        Yast::Kdump.KDUMP_SETTINGS["KDUMP_SAVEDIR"] = "nfs://server/export/var/log/dump"
+        expect(Yast::Kdump.free_space_for_dump).to eq(nil)
+
+        Yast::Kdump.KDUMP_SETTINGS["KDUMP_SAVEDIR"] = "ssh://user:password@host/var/log/dump"
+        expect(Yast::Kdump.free_space_for_dump).to eq(nil)
+      end
+    end
+
+    context "when empty partition info is available" do
+      it "returns 'nil'" do
+        allow(Yast::SpaceCalculation).to receive(:GetPartitionInfo).and_return([])
+        expect(Yast::Kdump.free_space_for_dump).to eq(nil)
+      end
+    end
+
+    context "when partition does not provide free space information" do
+      it "returns 'nil'" do
+        allow(Yast::SpaceCalculation).to receive(:GetPartitionInfo).and_return([{"free"=>nil, "name"=>"var/crash"}])
+        expect(Yast::Kdump.free_space_for_dump).to eq(nil)
+
+        allow(Yast::SpaceCalculation).to receive(:GetPartitionInfo).and_return([{"name"=>"var/crash"}])
+        expect(Yast::Kdump.free_space_for_dump).to eq(nil)
+      end
+    end
+  end
+
+  # in MB
+  let(:total_memory_size) { 8 * 1024 ** 2 }
+
+  describe "#space_requested_for_dump" do
+    it "" do
+      allow(Yast::Kdump).to receive(:total_memory).and_return(total_memory_size)
+
+      expect(Yast::Kdump.space_requested_for_dump).to eq(total_memory_size * 1024**2 + 4 * 1024**3)
+    end
+  end
+
+  describe "#proposal_warnig" do
+    before do
+      allow(Yast::Kdump).to receive(:space_requested_for_dump).and_return(4 * 1024**4)
+      Yast::Kdump.instance_variable_set("@add_crashkernel_param", true)
+    end
+
+    context "when kdump is not enabled" do
+      it "returns empty hash" do
+        Yast::Kdump.instance_variable_set("@add_crashkernel_param", false)
+
+        warning = Yast::Kdump.proposal_warnig
+        expect(warning).to eq({})
+      end
+    end
+
+    context "when free space is smaller than requested" do
+      it "returns hash with warning and warning_level keys" do
+        allow(Yast::Kdump).to receive(:free_space_for_dump).and_return(3.89 * 1024**4)
+
+        warning = Yast::Kdump.proposal_warnig
+        expect(warning["warning"]).to match(/not enough free space/)
+        expect(warning["warning_level"]).not_to eq(nil)
+      end
+    end
+
+    context "when free space is bigger or equal to requested size" do
+      it "returns empty hash" do
+        allow(Yast::Kdump).to receive(:free_space_for_dump).and_return(120 * 1024**4)
+
+        warning = Yast::Kdump.proposal_warnig
+        expect(warning).to eq({})
       end
     end
   end

--- a/test/kdump_test.rb
+++ b/test/kdump_test.rb
@@ -150,16 +150,6 @@ describe Yast::Kdump do
       end
     end
 
-    context "when free space is nearly as big as reqeuested, but still smaller" do
-      it "returns hash with warning and warning_level keys" do
-        allow(Yast::Kdump).to receive(:free_space_for_dump_b).and_return(Yast::Kdump.space_requested_for_dump_b - 30 * 1024**2)
-
-        warning = Yast::Kdump.proposal_warning
-        expect(warning["warning"]).to match(/There might not be enough free space.*additional.*are missing/)
-        expect(warning["warning_level"]).not_to eq(nil)
-      end
-    end
-
     context "when free space is bigger or equal to requested size" do
       it "returns empty hash" do
         allow(Yast::Kdump).to receive(:free_space_for_dump_b).and_return(120 * 1024**3)


### PR DESCRIPTION
* Uses new API implemented here https://github.com/yast/yast-installation/pull/292
* FATE#317488: YaST kdump: issue warning, if space on "/" is smaller than (RAM + 4Gib)
