### PR TITLE
Fix writing boot parameter during autoupgrade

### DIFF
--- a/src/modules/Kdump.rb
+++ b/src/modules/Kdump.rb
@@ -541,12 +541,12 @@ module Yast
 
       if @add_crashkernel_param
         crash_value = ""
-        crash_value = BuildCrashkernelValue() if !Mode.autoinst
+        crash_value = BuildCrashkernelValue() if !(Mode.autoinst || Mode.autoupgrade)
 
         if !@crashkernel_param || crash_value != @crashkernel_param_value
-          crash_value = @crashkernel_param_value if Mode.autoinst
-
-          if Mode.update
+          if Mode.autoinst || Mode.autoupgrade
+            crash_value = @crashkernel_param_value
+          elsif Mode.update
             if Builtins.search(crash_value, "@") != nil
               tmp_crash_value = Builtins.splitstring(crash_value, "@")
               crash_value = Ops.get(tmp_crash_value, 0, "")


### PR DESCRIPTION
Autoupgrade is not handled in a proper way (the parameter is removed from the kernel command line), so this PR should fix the issue. Now autoinst and autoupgrade are handled in the same way. To summarize:

* When using autoinst/autoupgrade, crashkernel parameter is copied from the profile as is (without any modifications).
* When using the UI, offsets ('@') are not allowed (the value goes through some clean-up).

Is this intentional?