### PR TITLE
Update rnc specification to allow crash_kernel values list

### DIFF
--- a/package/yast2-kdump.changes
+++ b/package/yast2-kdump.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Sep 29 07:03:30 UTC 2015 - igonzalezsosa@suse.com
+
+- Update AutoYaST rnc to allow specifying multiple values
+  for crash_kernel parameter (bnc#882082).
+- 3.1.31
+
+-------------------------------------------------------------------
 Mon Sep 28 14:37:26 UTC 2015 - ancor@suse.com
 
 - Prevent kdumptool to be called more than once (bnc#882082)

--- a/package/yast2-kdump.spec
+++ b/package/yast2-kdump.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-kdump
-Version:        3.1.30
+Version:        3.1.31
 Release:        0
 Summary:        Configuration of kdump
 License:        GPL-2.0

--- a/src/autoyast-rnc/kdump.rnc
+++ b/src/autoyast-rnc/kdump.rnc
@@ -5,12 +5,17 @@ namespace config = "http://www.suse.com/1.0/configns"
 
 kdump =
   element kdump {
-     kdump_crash_kernel? &
+     (kdump_crash_kernel_value | kdump_crash_kernel_list)? &
      kdump_add_crash_kernel? &
      kdump_general?
 }
 
-kdump_crash_kernel = element crash_kernel { text }
+kdump_crash_kernel_value = element crash_kernel { text }
+kdump_crash_kernel_list = element crash_kernel {
+     LIST,
+     kdump_crash_kernel_entry+
+}
+kdump_crash_kernel_entry = element listentry { text }
 kdump_add_crash_kernel = element add_crash_kernel { BOOLEAN }
 
 kdump_general =


### PR DESCRIPTION
@schubi2 I've tested manually that it can be converted to rng (using trang) but I'm not sure about how to improve testing on that.

BTW, it should be reflected in AutoYaST documentation.

This PR should be merged when as part of bugfix for https://bugzilla.suse.com/show_bug.cgi?id=882082.