### PR TITLE
 Bring back a lost commit

### DIFF
--- a/package/yast2-kdump.changes
+++ b/package/yast2-kdump.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Sep 21 10:47:53 UTC 2015 - ancor@suse.com
+
+- More robust fix for bnc#946639 (see previous changelog message),
+  including better test coverage.
+- 3.1.29
+
+-------------------------------------------------------------------
 Mon Sep 21 09:39:07 UTC 2015 - ancor@suse.com
 
 - Fixed a crash during system update (bnc#946639)

--- a/package/yast2-kdump.spec
+++ b/package/yast2-kdump.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-kdump
-Version:        3.1.28
+Version:        3.1.29
 Release:        0
 Summary:        Configuration of kdump
 License:        GPL-2.0

--- a/src/modules/Kdump.rb
+++ b/src/modules/Kdump.rb
@@ -1100,7 +1100,7 @@ module Yast
       # If the current values include "nasty" things and the user has not
       # overriden the value of @crashkernel_list_ranges to autorize the
       # modification, return the old values (ensuring the Array format)
-      return Array(@crashkernel_param_values) if @crashkernel_list_ranges
+      return Array(@crashkernel_param_values.dup) if @crashkernel_list_ranges
 
       result = []
       high = @allocated_memory[:high]


### PR DESCRIPTION
When we switched developer during vacation period, a whole commit was left behind. That resulted in bnc#946639, some test coverage decrease and another subtle bug (not reported yet).

This commits brings back the missing bits from that lost commit (the rest was already reimplemented as a fix for bnc#946639).

The commit also contained a quite lengthly message, reproduced below:
"It actually has been a long time since the code for removing offsets was included in any workflow (i.e. used at all). This commit not only fixes the code (broken by the latests changes), but also ensures it's called again"