### PR TITLE
Fix defective test

### DIFF
--- a/test/kdump_test.rb
+++ b/test/kdump_test.rb
@@ -368,7 +368,7 @@ describe Yast::Kdump do
     before do
       Yast::Mode.SetMode(mode)
       # FIXME: current tests do not cover fadump (ppc64 specific)
-      allow(Yast::Kdump).to receive(:fadump_supported?).and_return false
+      allow(Yast::Kdump.system).to receive(:supports_fadump?).and_return false
     end
 
     context "during autoinstallation" do


### PR DESCRIPTION
Looks like I branched my previous pull request from an outdated master. Thus, I missed this call to fadump_supported.