### PR TITLE
Bootloader optimization

### DIFF
--- a/package/yast2-kdump.changes
+++ b/package/yast2-kdump.changes
@@ -1,8 +1,8 @@
 -------------------------------------------------------------------
 Mon Jun 27 13:23:28 UTC 2016 - jreidinger@suse.com
 
-- Skip writting bootloader configuration in installation, as it
-  will written later by yast2-bootloader. This will speed up
+- Skip writing bootloader configuration in installation, as it
+  will be written later by yast2-bootloader. This will speed up
   installation. (bnc#984649)
 - 3.1.38
 

--- a/package/yast2-kdump.changes
+++ b/package/yast2-kdump.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Jun 27 13:23:28 UTC 2016 - jreidinger@suse.com
+
+- Skip writting bootloader configuration in installation, as it
+  will written later by yast2-bootloader. This will speed up
+  installation. (bnc#984649)
+- 3.1.38
+
+-------------------------------------------------------------------
 Wed Apr 13 11:47:38 UTC 2016 - jreidinger@suse.com
 
 - Remove unused import of dropped BootCommon package

--- a/package/yast2-kdump.spec
+++ b/package/yast2-kdump.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-kdump
-Version:        3.1.37
+Version:        3.1.38
 Release:        0
 Summary:        Configuration of kdump
 License:        GPL-2.0
@@ -43,6 +43,8 @@ Requires:       yast2-ruby-bindings >= 1.0.0
 Requires:       yast2-storage
 # SpaceCalculation.GetPartitionInfo
 Requires:       yast2-packager
+# do not use old installation with wrong finish order
+Conflicts:      yast2-installation < 3.1.198
 Recommends:     makedumpfile
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 %ifarch ppc

--- a/src/modules/Kdump.rb
+++ b/src/modules/Kdump.rb
@@ -468,9 +468,12 @@ module Yast
           Service.Restart(KDUMP_SERVICE_NAME) if Service.active?(KDUMP_SERVICE_NAME)
         else
           Bootloader.modify_kernel_params(:common, :xen_guest, :recovery, "crashkernel" => crash_values)
-          old_progress = Progress.set(false)
-          Bootloader.Write
-          Progress.set(old_progress)
+          # do mass write in installation to speed up, so skip this one
+          if !Stage.initial
+            old_progress = Progress.set(false)
+            Bootloader.Write
+            Progress.set(old_progress)
+          end
           Builtins.y2milestone(
             "[kdump] (WriteKdumpBootParameter) adding chrashkernel options with values: %1",
             crash_values
@@ -483,9 +486,11 @@ module Yast
         if @crashkernel_param
           #delete crashkernel parameter from bootloader
           Bootloader.modify_kernel_params(:common, :xen_guest, :recovery, "crashkernel" => :missing)
-          old_progress = Progress.set(false)
-          Bootloader.Write
-          Progress.set(old_progress)
+          if !Stage.initial
+            old_progress = Progress.set(false)
+            Bootloader.Write
+            Progress.set(old_progress)
+          end
           reboot_needed = true
         end
         Service.Disable(KDUMP_SERVICE_NAME)
@@ -1125,7 +1130,7 @@ module Yast
             value = nil
         end
         Bootloader.modify_kernel_params(:common, :xen_guest, :recovery, "fadump" => value)
-        Bootloader.Write
+        Bootloader.Write unless Yast::Stage.initial # do mass write in installation to speed up
       end
     end
   end


### PR DESCRIPTION
related to https://github.com/yast/yast-installation/pull/398

Measured in default SLE12SP2 installation on x86_64 in QEMU.

Without this modification bootloader part took 58 seconds, in installation with dud applied it took 45 seconds. So it saves 13 seconds.