### PR TITLE
Do not enable kdump on aarch64 by default

### DIFF
--- a/package/yast2-kdump.changes
+++ b/package/yast2-kdump.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jul 20 13:48:18 CEST 2016 - locilka@suse.com
+
+- Proposing kdump to be disabled by default on ARM64 (bsc#989321)
+- 3.1.39
+
+-------------------------------------------------------------------
 Mon Jun 27 13:23:28 UTC 2016 - jreidinger@suse.com
 
 - Skip writing bootloader configuration in installation, as it

--- a/package/yast2-kdump.spec
+++ b/package/yast2-kdump.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-kdump
-Version:        3.1.38
+Version:        3.1.39
 Release:        0
 Summary:        Configuration of kdump
 License:        GPL-2.0

--- a/src/modules/Kdump.rb
+++ b/src/modules/Kdump.rb
@@ -661,9 +661,18 @@ module Yast
       @kdump_packages.concat KDUMP_PACKAGES
     end
 
+    # Proposes default state of kdump (enabled/disabled)
+    #
+    # @return [Boolean] the default proposed state
+
     def ProposeCrashkernelParam
-      # propose disable kdump if PC has less than 1024MB RAM
+      # proposing disabled kdump if PC has less than 1024MB RAM
       if total_memory < 1024
+        log.info "not enough memory - kdump proposed as disabled"
+        false
+      # proposing disabled kdump on aarch64 (bsc#989321) - kdump not implemented
+      elsif Arch.aarch64
+        log.info "aarch64 - kdump proposed as disabled"
         false
       else
         true

--- a/test/kdump_test.rb
+++ b/test/kdump_test.rb
@@ -46,6 +46,35 @@ describe Yast::Kdump do
     end
   end
 
+  describe "#ProposeCrashkernelParam" do
+    before do
+      allow(Yast::Kdump).to receive(:total_memory).and_return 1024
+      allow(Yast::Arch).to receive(:aarch64).and_return false
+    end
+
+    context "while running on machine with less than 1024 MB memory" do
+      it "proposes kdump to be disabled" do
+        allow(Yast::Kdump).to receive(:total_memory).and_return 1023
+
+        expect(Yast::Kdump.ProposeCrashkernelParam).to eq false
+      end
+    end
+
+    context "while running on ARM64" do
+      it "proposes kdump to be disabled" do
+        allow(Yast::Arch).to receive(:aarch64).and_return true
+
+        expect(Yast::Kdump.ProposeCrashkernelParam).to eq false
+      end
+    end
+
+    context "otherwise" do
+      it "always proposes kdump to be enabled" do
+        expect(Yast::Kdump.ProposeCrashkernelParam).to eq true
+      end
+    end
+  end
+
   let(:partition_info) do
     [
       { "free" => 389318, "name" => "/", "used" => 1487222 },


### PR DESCRIPTION
- Bug [989321 - Kdump should be disabled by default on arm64"](https://bugzilla.suse.com/show_bug.cgi?id=989321) defines, that kdump is not supported/implemented on ARM64 and thus should be be proposed in enabled state
- At this point, I haven't implemented a any warning if the user chooses to enable it manually
- There was another possibility to remove kdump proposal for ARM64 from from control file, but that would be very intrusive change, that's something I did not want to do at this stage of SLE 12 SP2