### PR TITLE
Do not warning when running in a HVM Xen guest

### DIFF
--- a/package/yast2-kdump.changes
+++ b/package/yast2-kdump.changes
@@ -2,7 +2,7 @@
 Mon Nov 30 15:50:47 UTC 2020 - David Diaz <dgonzalez@suse.com>
 
 - Do not show a warning when running in a HVM Xen guest
-  (bsc#https://bugzilla.suse.com/show_bug.cgi?id=1179197)
+  (bsc#1179197).
 - 4.3.3
 
 -------------------------------------------------------------------

--- a/package/yast2-kdump.changes
+++ b/package/yast2-kdump.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Nov 30 15:50:47 UTC 2020 - David Diaz <dgonzalez@suse.com>
+
+- Do not show a warning when running in a HVM Xen guest
+  (bsc#https://bugzilla.suse.com/show_bug.cgi?id=1179197)
+- 4.3.3
+
+-------------------------------------------------------------------
 Mon Aug 10 16:20:25 CEST 2020 - schubi@suse.de
 
 - AutoYaST: Added supplements: autoyast(kdump) into the spec file

--- a/package/yast2-kdump.spec
+++ b/package/yast2-kdump.spec
@@ -30,12 +30,13 @@ BuildRequires:  rubygem(%{rb_default_ruby_abi}:rspec)
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:yast-rake)
 BuildRequires:  update-desktop-files
 BuildRequires:  yast2
-# Wizard::SetDesktopTitleAndIcon
-BuildRequires:  yast2 >= 2.21.22
+# Yast::Aarch.paravirtualized_xen_guest?
+BuildRequires:  yast2 >= 4.3.45
 BuildRequires:  yast2-bootloader
 BuildRequires:  yast2-buildtools >= 4.2.2
 
-Requires:       yast2
+# Yast::Aarch.paravirtualized_xen_guest?
+Requires:       yast2 >= 4.3.45
 # Kernel parameters with multiple values and bug#945479 fixed
 Requires:       yast2-bootloader >= 3.1.148
 Requires:       yast2-ruby-bindings >= 1.0.0

--- a/package/yast2-kdump.spec
+++ b/package/yast2-kdump.spec
@@ -30,12 +30,12 @@ BuildRequires:  rubygem(%{rb_default_ruby_abi}:rspec)
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:yast-rake)
 BuildRequires:  update-desktop-files
 BuildRequires:  yast2
-# Yast::Aarch.paravirtualized_xen_guest?
+# Yast::Arch.paravirtualized_xen_guest?
 BuildRequires:  yast2 >= 4.3.45
 BuildRequires:  yast2-bootloader
 BuildRequires:  yast2-buildtools >= 4.2.2
 
-# Yast::Aarch.paravirtualized_xen_guest?
+# Yast::Arch.paravirtualized_xen_guest?
 Requires:       yast2 >= 4.3.45
 # Kernel parameters with multiple values and bug#945479 fixed
 Requires:       yast2-bootloader >= 3.1.148

--- a/package/yast2-kdump.spec
+++ b/package/yast2-kdump.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-kdump
-Version:        4.3.2
+Version:        4.3.3
 Release:        0
 Summary:        Configuration of kdump
 License:        GPL-2.0-only

--- a/src/lib/kdump/kdump_system.rb
+++ b/src/lib/kdump/kdump_system.rb
@@ -44,11 +44,11 @@ module Yast
 
     # Check whether the system supports kdump
     #
-    # See bsc#952253. Kdump cannot work in DomU
+    # See bsc#952253. Kdump cannot work in a PV DomU
     #
     # @return [Boolean] true if kdump is supported, false otherwise
     def supports_kdump?
-      !Arch.is_xenU
+      !Arch.paravirtualized_xen_guest?
     end
 
     # Physical memory (in MiB) reported by the kernel.

--- a/test/lib/kdump_system_test.rb
+++ b/test/lib/kdump_system_test.rb
@@ -30,19 +30,19 @@ describe Yast::KdumpSystem do
 
   describe "#supports_kdump?" do
     before do
-      allow(Yast::Arch).to receive(:is_xenU).and_return xenU
+      allow(Yast::Arch).to receive(:paravirtualized_xen_guest?).and_return xen_pv_domU
     end
 
-    context "in a Xen DomU" do
-      let(:xenU) { true }
+    context "in a Xen PV DomU" do
+      let(:xen_pv_domU) { true }
 
       it "returns false" do
         expect(subject.supports_kdump?).to eq false
       end
     end
 
-    context "in a system not being a Xen DomU" do
-      let(:xenU) { false }
+    context "in a system not being a Xen PV DomU" do
+      let(:xen_pv_domU) { false }
 
       it "returns true" do
         expect(subject.supports_kdump?).to eq true


### PR DESCRIPTION
## Problem

`yast-kdump` displays a warning when running on a Xen **HVM** guest. Such warning should appear only when running in a **PV** Xen guest.

  * https://bugzilla.suse.com/show_bug.cgi?id=1179197
  * https://bugzilla.suse.com/show_bug.cgi?id=952253#c8
  * https://trello.com/c/uqdMdM0n/2198-sles15-sp3-p2-1179197-build-20140-kdump-not-supported-in-xen-hvm

## Solution :warning: **requires yast2 >= 4.3.45** :warning:

Start using the new method `Yast::Arch.previrtualized_xen_guest?` added in `yast2 4.3.45`. See https://github.com/yast/yast-yast2/pull/1120 to know more.


## Testing

* Unit test adapted
* Tested manually