### PR TITLE
Fix popup

### DIFF
--- a/package/yast2-kdump.changes
+++ b/package/yast2-kdump.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Feb 18 15:37:11 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
+
+- Adapted unit test to recent changes in Yast::Report (related to
+  bsc#1179893).
+- 4.3.4
+
+-------------------------------------------------------------------
 Mon Nov 30 15:50:47 UTC 2020 - David Diaz <dgonzalez@suse.com>
 
 - Do not show a warning when running in a HVM Xen guest

--- a/package/yast2-kdump.spec
+++ b/package/yast2-kdump.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-kdump
-Version:        4.3.3
+Version:        4.3.4
 Release:        0
 Summary:        Configuration of kdump
 License:        GPL-2.0-only

--- a/test/fadump_test.rb
+++ b/test/fadump_test.rb
@@ -24,7 +24,8 @@ describe "#use_fadump" do
   context "if fadump is not supported on this architecture" do
     let(:supported) { false }
 
-    it "returns false when enabling fadump" do
+    it "returns false and show error popup when enabling fadump" do
+      expect(Yast::Report).to receive(:Error)
       expect(Yast::Kdump.use_fadump(true)).to eq(false)
     end
 


### PR DESCRIPTION
This pull request in yast-yast2 (yast/yast-yast2#1122) changed the behavior during unit tests of Yast::Report and Yast2::Popup, making necessary to add some extra mocking to prevent YaST from trying to open windows during the test execution.

As far as we know, that affected the test-suites of: yast-storage-ng, yast-country, yast-firewall, yast-nfs-server, yast-nis-client, yast-pam, yast-security, yast-services-manager and yast-sysconfig.

This should fix the problem for this repository.