### PR TITLE
Implement KDUMP_AUTO_RESIZE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,10 @@ jobs:
     - name: Git Checkout
       uses: actions/checkout@v1
 
+    - name: Git Fix
+      # fix the ownership to pass a git security check
+      run: chown "$UID" .
+
     # just for easier debugging...
     - name: Inspect Installed Packages
       run: rpm -qa | sort

--- a/src/autoyast-rnc/kdump.rnc
+++ b/src/autoyast-rnc/kdump.rnc
@@ -36,6 +36,7 @@ kdump_general = element general {
     element KDUMP_CPUS { STRING }? &
     element KDUMP_COMMANDLINE { STRING }? &
     element KDUMP_COMMANDLINE_APPEND { STRING }? &
+    element KDUMP_AUTO_RESIZE { STRING }? &
     element KDUMP_CONTINUE_ON_ERROR { STRING }? &
     element KDUMP_REQUIRED_PROGRAMS { STRING }? &
     element KDUMP_PRESCRIPT { STRING }? &

--- a/src/include/kdump/dialogs.rb
+++ b/src/include/kdump/dialogs.rb
@@ -567,23 +567,29 @@ module Yast
             HStretch()
           )
         ),
-        VSpacing(1),
-        Left(
-          HBox(
-            Left(Label(_("Usable Memory [MiB]:"))),
-            Left(Label(Id("usable_memory"), "0123456789")),
-            HStretch()
-          )
-        ),
-        VSpacing(1),
-        Left(IntField(Id("allocated_low_memory"),
-          Opt(:notify),
-          low_label,
-          low_min,
-          low_max,
-          0)),
-        Left(Label(low_range)),
-        *high_widgets
+        VBox(
+          Id(:allocated_memory_box),
+          Left(
+            HBox(
+              Left(Label(_("Usable Memory [MiB]:"))),
+              Left(Label(Id("usable_memory"), "0123456789")),
+              HStretch()
+            )
+          ),
+          VSpacing(1),
+          Left(
+            IntField(
+              Id("allocated_low_memory"),
+              Opt(:notify),
+              low_label,
+              low_min,
+              low_max,
+              0
+            )
+          ),
+          Left(Label(low_range)),
+          *high_widgets
+        )
       )
     end
 

--- a/src/include/kdump/dialogs.rb
+++ b/src/include/kdump/dialogs.rb
@@ -561,6 +561,15 @@ module Yast
       end
       VBox(
         Left(
+          CheckBox(
+            Id(:auto_resize),
+            Opt(:notify),
+            _("&Automatically Resize at Boot"),
+            false
+          )
+        ),
+        VSpacing(1),
+        Left(
           HBox(
             Left(Label(_("Total System Memory [MiB]:"))),
             Left(Label(Id("total_memory"), "0123456789")),

--- a/src/include/kdump/dialogs.rb
+++ b/src/include/kdump/dialogs.rb
@@ -570,7 +570,7 @@ module Yast
           Left(
             HBox(
               Left(Label(_("Usable Memory [MiB]:"))),
-              Left(ReplacePoint(Id("usable_memory_rp"), usable_memory_widget),
+              Left(ReplacePoint(Id("usable_memory_rp"), usable_memory_widget)),
               HStretch()
             )
           ),

--- a/src/include/kdump/dialogs.rb
+++ b/src/include/kdump/dialogs.rb
@@ -536,7 +536,30 @@ module Yast
         min:     low_min,
         max:     low_max,
         default: low_default)
-      widgets = [
+      high_widgets = []
+      if Kdump.high_memory_supported?
+        high_min = Kdump.memory_limits[:min_high].to_i
+        high_max = Kdump.memory_limits[:max_high].to_i
+        high_default = Kdump.memory_limits[:default_high].to_i
+        # TRANSLATORS: %{min}, %{max}, %{default} are variable names which must not be translated.
+        high_range = format(_("(min: %{min}; max: %{max}; suggested: %{default})"),
+          min:     high_min,
+          max:     high_max,
+          default: high_default)
+        high_widgets << VSpacing(1)
+        high_widgets << Left(
+          IntField(
+            Id("allocated_high_memory"),
+            Opt(:notify),
+            _("Kdump &High Memory [MiB]"),
+            high_min,
+            high_max,
+            0
+          )
+        )
+        high_widgets << Left(Label(high_range))
+      end
+      VBox(
         Left(
           HBox(
             Left(Label(_("Total System Memory [MiB]:"))),
@@ -559,31 +582,9 @@ module Yast
           low_min,
           low_max,
           0)),
-        Left(Label(low_range))
-      ]
-      if Kdump.high_memory_supported?
-        high_min = Kdump.memory_limits[:min_high].to_i
-        high_max = Kdump.memory_limits[:max_high].to_i
-        high_default = Kdump.memory_limits[:default_high].to_i
-        # TRANSLATORS: %{min}, %{max}, %{default} are variable names which must not be translated.
-        high_range = format(_("(min: %{min}; max: %{max}; suggested: %{default})"),
-          min:     high_min,
-          max:     high_max,
-          default: high_default)
-        widgets << VSpacing(1)
-        widgets << Left(
-          IntField(
-            Id("allocated_high_memory"),
-            Opt(:notify),
-            _("Kdump &High Memory [MiB]"),
-            high_min,
-            high_max,
-            0
-          )
-        )
-        widgets << Left(Label(high_range))
-      end
-      VBox(*widgets)
+        Left(Label(low_range)),
+        *high_widgets
+      )
     end
 
     def DisBackButton(_key)

--- a/src/include/kdump/uifunctions.rb
+++ b/src/include/kdump/uifunctions.rb
@@ -1360,12 +1360,9 @@ module Yast
         end
         update_usable_memory
       else
+        UI.ChangeWidget(Id(:allocated_memory_box), :Enabled, false)
         UI.ChangeWidget(Id("total_memory"), :Value, "0")
         UI.ChangeWidget(Id("usable_memory"), :Value, "0")
-        UI.ChangeWidget(Id("allocated_low_memory"), :Enabled, false)
-        if Kdump.high_memory_supported?
-          UI.ChangeWidget(Id("allocated_high_memory"), :Enabled, false)
-        end
       end
 
       nil

--- a/src/include/kdump/uifunctions.rb
+++ b/src/include/kdump/uifunctions.rb
@@ -1340,6 +1340,8 @@ module Yast
     # Function initializes option
     # "KdumpMemory"
     def InitKdumpMemory(_key)
+      auto_resize = Kdump.KDUMP_SETTINGS["KDUMP_AUTO_RESIZE"] == "yes"
+      UI.ChangeWidget(Id(:auto_resize), :Value, auto_resize)
       if Kdump.total_memory > 0
         UI.ChangeWidget(
           Id("total_memory"),
@@ -1402,6 +1404,8 @@ module Yast
     #  Store function for option
     # "KdumpMemory"
     def StoreKdumpMemory(_key, _event)
+      Kdump.KDUMP_SETTINGS["KDUMP_AUTO_RESIZE"] =
+        UI.QueryWidget(Id(:auto_resize), :Value) ? "yes" : "no"
       Kdump.allocated_memory[:low] = Builtins.tostring(
         UI.QueryWidget(Id("allocated_low_memory"), :Value)
       )

--- a/src/include/kdump/uifunctions.rb
+++ b/src/include/kdump/uifunctions.rb
@@ -1333,7 +1333,11 @@ module Yast
 
     # Updates the free memory displayed in the UI
     def update_usable_memory
-      value = Kdump.total_memory - allocated_memory
+      value = if UI.QueryWidget(Id(:auto_resize), :Value)
+        "---"
+      else
+        Kdump.total_memory - allocated_memory
+      end
       UI.ChangeWidget(Id("usable_memory"), :Value, value.to_s)
     end
 
@@ -1381,6 +1385,8 @@ module Yast
           # Substract (remaining is negative) the excess from the current value
           UI.ChangeWidget(Id(ret), :Value, send(ret.to_sym) + remaining)
         end
+        update_usable_memory
+      elsif ret == :auto_resize
         update_usable_memory
       end
 

--- a/src/include/kdump/uifunctions.rb
+++ b/src/include/kdump/uifunctions.rb
@@ -1344,7 +1344,12 @@ module Yast
     # Function initializes option
     # "KdumpMemory"
     def InitKdumpMemory(_key)
-      auto_resize = Kdump.KDUMP_SETTINGS["KDUMP_AUTO_RESIZE"] == "yes"
+      if Kdump.using_fadump?
+        UI.ChangeWidget(Id(:auto_resize), :Enabled, false)
+        auto_resize = false
+      else
+        auto_resize = Kdump.KDUMP_SETTINGS["KDUMP_AUTO_RESIZE"] == "yes"
+      end
       UI.ChangeWidget(Id(:auto_resize), :Value, auto_resize)
       if Kdump.total_memory > 0
         UI.ChangeWidget(Id(:allocated_memory_box), :Enabled, !auto_resize)
@@ -1453,6 +1458,14 @@ module Yast
       if !Kdump.use_fadump(UI.QueryWidget(Id("use_fadump"), :Value))
         UI.ChangeWidget(Id("use_fadump"), :Value, false)
       end
+
+      value = UI.QueryWidget(Id("use_fadump"), :Value)
+      if value
+        UI.ChangeWidget(Id(:auto_resize), :Value, false)
+        UI.ChangeWidget(Id(:allocated_memory_box), :Enabled, true)
+        update_usable_memory
+      end
+      UI.ChangeWidget(Id(:auto_resize), :Enabled, !value)
 
       nil
     end

--- a/src/include/kdump/uifunctions.rb
+++ b/src/include/kdump/uifunctions.rb
@@ -1347,6 +1347,7 @@ module Yast
       auto_resize = Kdump.KDUMP_SETTINGS["KDUMP_AUTO_RESIZE"] == "yes"
       UI.ChangeWidget(Id(:auto_resize), :Value, auto_resize)
       if Kdump.total_memory > 0
+        UI.ChangeWidget(Id(:allocated_memory_box), :Enabled, !auto_resize)
         UI.ChangeWidget(
           Id("total_memory"),
           :Value,
@@ -1387,6 +1388,8 @@ module Yast
         end
         update_usable_memory
       elsif ret == :auto_resize
+        value = UI.QueryWidget(Id(ret), :Value)
+        UI.ChangeWidget(Id(:allocated_memory_box), :Enabled, !value)
         update_usable_memory
       end
 

--- a/src/modules/Kdump.rb
+++ b/src/modules/Kdump.rb
@@ -149,6 +149,7 @@ module Yast
         "KDUMP_CPUS"               => "",
         "KDUMP_COMMANDLINE"        => "",
         "KDUMP_COMMANDLINE_APPEND" => "",
+        "KDUMP_AUTO_RESIZE"        => "yes",
         "KEXEC_OPTIONS"            => "",
         "KDUMP_IMMEDIATE_REBOOT"   => "yes",
         "KDUMP_COPY_KERNEL"        => "yes",

--- a/src/modules/Kdump.rb
+++ b/src/modules/Kdump.rb
@@ -1134,9 +1134,22 @@ module Yast
       end
 
       result = []
-      high = @allocated_memory[:high]
-      result << high + "M,high" if high && high.to_i != 0
-      low = @allocated_memory[:low]
+      if @KDUMP_SETTINGS["KDUMP_AUTO_RESIZE"] == "yes"
+        maxsize = total_memory / 2
+        if high_memory_supported?
+          low = memory_limits[:default_low]
+          high = memory_limits[:max_high]
+          high = (maxsize - low.to_i).to_s if high.to_i > maxsize
+        else
+          high = memory_limits[:min_high]
+          low = memory_limits[:max_low]
+          low = maxsize.to_s if low.to_i > maxsize
+        end
+      else
+        high = @allocated_memory[:high]
+        low = @allocated_memory[:low]
+      end
+      result << "#{high}M,high" if high && high.to_i != 0
       # Add the ',low' suffix only there is a ',high' one
       result << (result.empty? ? "#{low}M" : "#{low}M,low") if low && low.to_i != 0
 
@@ -1159,8 +1172,13 @@ module Yast
       end
 
       result = []
-      high = @allocated_memory[:high]
-      low = @allocated_memory[:low]
+      if @KDUMP_SETTINGS["KDUMP_AUTO_RESIZE"] == "yes"
+        high = memory_limits[:default_high]
+        low = memory_limits[:default_low]
+      else
+        high = @allocated_memory[:high]
+        low = @allocated_memory[:low]
+      end
       sum = 0
       sum += low.to_i if low
       sum += high.to_i if high

--- a/test/kdump_test.rb
+++ b/test/kdump_test.rb
@@ -434,6 +434,7 @@ describe Yast::Kdump do
 
     context "during autoinstallation" do
       let(:bootlader_kernel_params) { ["2047M,high"] }
+      let(:bootloader_kernel_params_noauto) { ["73M,high"] }
       let(:bootlader_xen_kernel_params) { ["73M\\<4G"] }
 
       before do
@@ -496,6 +497,23 @@ describe Yast::Kdump do
         end
       end
 
+      context "if kdump is requested, no value for crashkernel is supplied, and auto-resize is disabled" do
+        let(:profile) { { "add_crash_kernel" => true, "general" => { "KDUMP_AUTO_RESIZE" => "no" } } }
+
+        it "writes a proposed crashkernel in the bootloader and enables the service" do
+          expect(Yast::Bootloader)
+            .to receive(:modify_kernel_params)
+            .with(:common, :recovery, "crashkernel" => bootloader_kernel_params_noauto)
+          expect(Yast::Bootloader)
+            .to receive(:modify_kernel_params)
+            .with(:xen_host, "crashkernel" => bootlader_xen_kernel_params)
+          expect(Yast::Bootloader).to receive(:Write)
+          expect(Yast::Service).to receive(:Enable).with("kdump")
+
+          Yast::Kdump.WriteKdumpBootParameter
+        end
+      end
+
       context "if kdump is explicitly disabled" do
         let(:profile) { { "add_crash_kernel" => false, "crash_kernel" => "does_not_matter" } }
 
@@ -530,6 +548,7 @@ describe Yast::Kdump do
 
     context "during autoupgrade" do
       let(:bootlader_kernel_params) { ["1968M,high"] }
+      let(:bootloader_kernel_params_noauto) { ["75M,high"] }
       let(:bootlader_xen_kernel_params) { ["75M\\<4G"] }
 
       before do
@@ -582,6 +601,23 @@ describe Yast::Kdump do
           expect(Yast::Bootloader)
             .to receive(:modify_kernel_params)
             .with(:common, :recovery, "crashkernel" => bootlader_kernel_params)
+          expect(Yast::Bootloader)
+            .to receive(:modify_kernel_params)
+            .with(:xen_host, "crashkernel" => bootlader_xen_kernel_params)
+          expect(Yast::Bootloader).to receive(:Write)
+          expect(Yast::Service).to receive(:Enable).with("kdump")
+
+          Yast::Kdump.WriteKdumpBootParameter
+        end
+      end
+
+      context "if kdump is requested, no value for crashkernel is supplied, and auto-resize is disabled" do
+        let(:profile) { { "add_crash_kernel" => true, "general" => { "KDUMP_AUTO_RESIZE" => "no" } } }
+
+        it "rewrites the bootloader crashkernel settings and enables the service" do
+          expect(Yast::Bootloader)
+            .to receive(:modify_kernel_params)
+            .with(:common, :recovery, "crashkernel" => bootloader_kernel_params_noauto)
           expect(Yast::Bootloader)
             .to receive(:modify_kernel_params)
             .with(:xen_host, "crashkernel" => bootlader_xen_kernel_params)

--- a/test/kdump_test.rb
+++ b/test/kdump_test.rb
@@ -433,13 +433,15 @@ describe Yast::Kdump do
     end
 
     context "during autoinstallation" do
-      let(:bootlader_kernel_params) { ["73M,high"] }
+      let(:bootlader_kernel_params) { ["2047M,high"] }
       let(:bootlader_xen_kernel_params) { ["73M\\<4G"] }
 
       before do
         allow(Yast::Mode).to receive(:autoinst).and_return true
         allow(Yast::Kdump.calibrator).to receive(:default_low).and_return 0
         allow(Yast::Kdump.calibrator).to receive(:default_high).and_return 73
+        allow(Yast::Kdump.calibrator).to receive(:max_high).and_return 4092
+        allow(Yast::Kdump.calibrator).to receive(:total_memory).and_return 4095
         Yast::Kdump.Import(profile)
       end
 
@@ -527,13 +529,15 @@ describe Yast::Kdump do
     end
 
     context "during autoupgrade" do
-      let(:bootlader_kernel_params) { ["75M,high"] }
+      let(:bootlader_kernel_params) { ["1968M,high"] }
       let(:bootlader_xen_kernel_params) { ["75M\\<4G"] }
 
       before do
         allow(Yast::Mode).to receive(:autoupgrade).and_return true
         allow(Yast::Kdump.calibrator).to receive(:default_low).and_return 0
         allow(Yast::Kdump.calibrator).to receive(:default_high).and_return 75
+        allow(Yast::Kdump.calibrator).to receive(:max_high).and_return 1968
+        allow(Yast::Kdump.calibrator).to receive(:total_memory).and_return 4095
         Yast::Kdump.Import(profile)
       end
 
@@ -828,9 +832,14 @@ describe Yast::Kdump do
         allow(Yast::Mode).to receive(:autoinst).and_return true
       end
       let(:profile) do
-        { "add_crash_kernel" => true,
+        {
+          "add_crash_kernel" => true,
           "crash_kernel"     => "256M",
-          "general"          => { "KDUMP_SAVEDIR"=>"file:///var/dummy" } }
+          "general"          => {
+            "KDUMP_SAVEDIR"     => "file:///var/dummy",
+            "KDUMP_AUTO_RESIZE" => "no"
+          }
+        }
       end
       # bnc#995750
       it "does not override imported AutoYaST settings" do

--- a/test/kdump_test.rb
+++ b/test/kdump_test.rb
@@ -433,9 +433,9 @@ describe Yast::Kdump do
     end
 
     context "during autoinstallation" do
-      let(:bootlader_kernel_params) { ["2047M,high"] }
+      let(:bootloader_kernel_params) { ["2047M,high"] }
       let(:bootloader_kernel_params_noauto) { ["73M,high"] }
-      let(:bootlader_xen_kernel_params) { ["73M\\<4G"] }
+      let(:bootloader_xen_kernel_params) { ["73M\\<4G"] }
 
       before do
         allow(Yast::Mode).to receive(:autoinst).and_return true
@@ -486,10 +486,10 @@ describe Yast::Kdump do
         it "writes a proposed crashkernel in the bootloader and enables the service" do
           expect(Yast::Bootloader)
             .to receive(:modify_kernel_params)
-            .with(:common, :recovery, "crashkernel" => bootlader_kernel_params)
+            .with(:common, :recovery, "crashkernel" => bootloader_kernel_params)
           expect(Yast::Bootloader)
             .to receive(:modify_kernel_params)
-            .with(:xen_host, "crashkernel" => bootlader_xen_kernel_params)
+            .with(:xen_host, "crashkernel" => bootloader_xen_kernel_params)
           expect(Yast::Bootloader).to receive(:Write)
           expect(Yast::Service).to receive(:Enable).with("kdump")
 
@@ -506,7 +506,7 @@ describe Yast::Kdump do
             .with(:common, :recovery, "crashkernel" => bootloader_kernel_params_noauto)
           expect(Yast::Bootloader)
             .to receive(:modify_kernel_params)
-            .with(:xen_host, "crashkernel" => bootlader_xen_kernel_params)
+            .with(:xen_host, "crashkernel" => bootloader_xen_kernel_params)
           expect(Yast::Bootloader).to receive(:Write)
           expect(Yast::Service).to receive(:Enable).with("kdump")
 
@@ -547,9 +547,9 @@ describe Yast::Kdump do
     end
 
     context "during autoupgrade" do
-      let(:bootlader_kernel_params) { ["1968M,high"] }
+      let(:bootloader_kernel_params) { ["1968M,high"] }
       let(:bootloader_kernel_params_noauto) { ["75M,high"] }
-      let(:bootlader_xen_kernel_params) { ["75M\\<4G"] }
+      let(:bootloader_xen_kernel_params) { ["75M\\<4G"] }
 
       before do
         allow(Yast::Mode).to receive(:autoupgrade).and_return true
@@ -600,10 +600,10 @@ describe Yast::Kdump do
         it "rewrites the bootloader crashkernel settings and enables the service" do
           expect(Yast::Bootloader)
             .to receive(:modify_kernel_params)
-            .with(:common, :recovery, "crashkernel" => bootlader_kernel_params)
+            .with(:common, :recovery, "crashkernel" => bootloader_kernel_params)
           expect(Yast::Bootloader)
             .to receive(:modify_kernel_params)
-            .with(:xen_host, "crashkernel" => bootlader_xen_kernel_params)
+            .with(:xen_host, "crashkernel" => bootloader_xen_kernel_params)
           expect(Yast::Bootloader).to receive(:Write)
           expect(Yast::Service).to receive(:Enable).with("kdump")
 
@@ -620,7 +620,7 @@ describe Yast::Kdump do
             .with(:common, :recovery, "crashkernel" => bootloader_kernel_params_noauto)
           expect(Yast::Bootloader)
             .to receive(:modify_kernel_params)
-            .with(:xen_host, "crashkernel" => bootlader_xen_kernel_params)
+            .with(:xen_host, "crashkernel" => bootloader_xen_kernel_params)
           expect(Yast::Bootloader).to receive(:Write)
           expect(Yast::Service).to receive(:Enable).with("kdump")
 


### PR DESCRIPTION
[Kdump-1.0.1](https://github.com/openSUSE/kdump) adds a [new option to resize the crash kernel reservation automatically at boot](https://github.com/openSUSE/kdump/commit/60de244b333cc036c1d9d071e02fb4dbd9dd6e9a). It's non-trivial to use it properly, but the YaST module can be of great help!

This would have been the ultimate goal of [jsc#SLE-18441](https://jira.suse.com/browse/SLE-18441) "_Auto scale crashkernel size with hardware changes_", but yeah, I know it's probably too late now. If nothing else, Tumbleweed may benefit from this work.