### PR TITLE
Do not limit "low memory" when Firmware-Assisted Dump is enabled (ppc64 only)

### DIFF
--- a/package/yast2-kdump.changes
+++ b/package/yast2-kdump.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue May 10 10:04:49 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not limit to kdumptool MaxLow when using fadump (related
+  to jsc#SLE-21644).
+- 4.5.1
+
+-------------------------------------------------------------------
 Wed Apr 06 13:24:58 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Bump version to 4.5.0 (bsc#1198109)

--- a/package/yast2-kdump.spec
+++ b/package/yast2-kdump.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-kdump
-Version:        4.5.0
+Version:        4.5.1
 Release:        0
 Summary:        Configuration of kdump
 License:        GPL-2.0-only

--- a/src/include/kdump/uifunctions.rb
+++ b/src/include/kdump/uifunctions.rb
@@ -1334,7 +1334,7 @@ module Yast
     # Updates the free memory displayed in the UI
     def update_usable_memory
       value = Kdump.total_memory - allocated_memory
-      UI.ChangeWidget(Id("usable_memory"), :Value, value.to_s)
+      UI.ReplaceWidget(Id("usable_memory_rp"), usable_memory_widget(value))
     end
 
     # Function initializes option
@@ -1442,9 +1442,19 @@ module Yast
       # If cannot adjust the fadump usage
       if !Kdump.use_fadump(UI.QueryWidget(Id("use_fadump"), :Value))
         UI.ChangeWidget(Id("use_fadump"), :Value, false)
+        return
       end
 
+      refresh_kdump_memory
+      update_usable_memory
+
       nil
+    end
+
+    def refresh_kdump_memory
+      widget_id = Id("allocated_low_memory")
+      value = UI.QueryWidget(widget_id, :Value)
+      UI.ReplaceWidget(Id("allocated_low_memory_rp"), low_memory_widget(value))
     end
 
     # Function initializes option

--- a/src/modules/Kdump.rb
+++ b/src/modules/Kdump.rb
@@ -335,8 +335,19 @@ module Yast
       end
     end
 
+    # Returns the Kdump memory limits
+    #
+    # It relies on the calibrator but it adjust the low memory limits when using firmware-assisted
+    # dumps. The reason is that those limits might contradict the recommended value. See
+    # jsc#SLE-21644 for more information.
+    #
+    # @return [Hash] The hash contains the following keys: :min_low, :max_low,
+    #   :default_low, :min_high, :max_high, :default_high
     def memory_limits
-      calibrator.memory_limits
+      limits = calibrator.memory_limits
+      return limits unless using_fadump?
+
+      limits.merge(min_low: 0, max_low: total_memory)
     end
 
     # Propose reserved/allocated memory

--- a/test/kdump_test.rb
+++ b/test/kdump_test.rb
@@ -857,4 +857,55 @@ describe Yast::Kdump do
       expect(subject.Export).to eq("add_crash_kernel" => false)
     end
   end
+
+  describe ".memory_limits" do
+    let(:limits) do
+      {
+        min_low:      72,
+        max_low:      3154,
+        default_low:  72,
+        min_high:     0,
+        max_high:     4247,
+        default_high: 323
+      }
+    end
+
+    let(:calibrator) do
+      instance_double(
+        Yast::KdumpCalibrator,
+        total_memory:  16334,
+        memory_limits: limits
+      )
+    end
+
+    let(:fadump?) { false }
+
+    before do
+      allow(Yast::Kdump).to receive(:calibrator).and_return(calibrator)
+      allow(Yast::Kdump).to receive(:using_fadump?).and_return(fadump?)
+    end
+
+    it "returns a hash containing the memory limits from the calibrator" do
+      expect(subject.memory_limits).to eq(
+        min_low:      72,
+        max_low:      3154,
+        default_low:  72,
+        min_high:     0,
+        max_high:     4247,
+        default_high: 323
+      )
+    end
+
+    context "when fadump is enabled" do
+      let(:fadump?) { true }
+
+      it "returns the total memory as limit :max_low limit" do
+        expect(subject.memory_limits[:max_low]).to eq(16334)
+      end
+
+      it "returns :min_low as 0" do
+        expect(subject.memory_limits[:min_low]).to eq(0)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Bring #126 to `master`.