### PR TITLE
Removed kdump RPM dependency (related to bsc#1199840)

### DIFF
--- a/package/yast2-kdump.changes
+++ b/package/yast2-kdump.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Tue Jul 26 15:20:39 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Removed kdump RPM dependency, the package is checked and
+  installed at runtime. This removes the package from the YaST
+  container (related to bsc#1199840)
+- For the inst-sys dependencies the respective skelcd-control-*
+  packages have been updated.
+- 4.5.2
+
+-------------------------------------------------------------------
 Tue May 10 10:04:49 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not limit to kdumptool MaxLow when using fadump (related

--- a/package/yast2-kdump.spec
+++ b/package/yast2-kdump.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-kdump
-Version:        4.5.1
+Version:        4.5.2
 Release:        0
 Summary:        Configuration of kdump
 License:        GPL-2.0-only
@@ -43,14 +43,6 @@ Requires:       yast2-ruby-bindings >= 1.0.0
 # SpaceCalculation.GetPartitionInfo
 Requires:       yast2-packager
 # do not use old installation with wrong finish order
-
-%ifarch ppc
-Recommends:     kdump
-%else
-Requires:       kdump
-%endif
-Recommends:     makedumpfile
-
 Conflicts:      yast2-installation < 3.1.198
 
 Supplements:    (yast2 and kdump)


### PR DESCRIPTION
- The `kdump` package is checked and installed at runtime, the RPM dependency is a duplicate and it was added just to ensure the `kdump` package is included in the inst-sys. ([bsc#875765#c4](https://bugzilla.suse.com/show_bug.cgi?id=875765#c4))
- This removes the `kdump` package from the YaST container where it does not make sense, the package is needed in the target system
- For the inst-sys dependencies the respective `skelcd-control-*` packages have been updated.
- The `makedumpfile` package is required by `kdump` to it will be always installed, removing the redundant dependency
- 4.5.2
