### PR TITLE
support creating kdump initrd on transactional system

### DIFF
--- a/package/yast2-kdump.changes
+++ b/package/yast2-kdump.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Sep 12 08:24:53 UTC 2022 - Josef Reidinger <jreidinger@suse.com>
+
+- Allow kdump to run on transactional systems (bsc#1128853)
+- 4.5.4
+
+-------------------------------------------------------------------
 Mon Aug  1 11:53:29 UTC 2022 - David Diaz <dgonzalez@suse.com>
 
 - Allow using kdump auto resize (related to jsc#SLE-18441)

--- a/package/yast2-kdump.spec
+++ b/package/yast2-kdump.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-kdump
-Version:        4.5.3
+Version:        4.5.4
 Release:        0
 Summary:        Configuration of kdump
 License:        GPL-2.0-only

--- a/src/modules/Kdump.rb
+++ b/src/modules/Kdump.rb
@@ -51,23 +51,24 @@ module Yast
     def main
       textdomain "kdump"
 
-      Yast.import "Progress"
-      Yast.import "Report"
-      Yast.import "Summary"
-      Yast.import "Message"
-      Yast.import "Map"
-      Yast.import "Bootloader"
-      Yast.import "Service"
-      Yast.import "Popup"
       Yast.import "Arch"
+      Yast.import "Bootloader"
+      Yast.import "Directory"
+      Yast.import "FileUtils"
+      Yast.import "Map"
+      Yast.import "Message"
       Yast.import "Mode"
+      Yast.import "Package"
+      Yast.import "PackagesProposal"
+      Yast.import "Popup"
       Yast.import "ProductControl"
       Yast.import "ProductFeatures"
-      Yast.import "PackagesProposal"
-      Yast.import "FileUtils"
-      Yast.import "Directory"
-      Yast.import "String"
+      Yast.import "Progress"
+      Yast.import "Report"
+      Yast.import "Service"
       Yast.import "SpaceCalculation"
+      Yast.import "String"
+      Yast.import "Summary"
 
       reset
     end
@@ -405,6 +406,13 @@ module Yast
     #
     # @return [Boolean] whether successful
     def update_initrd
+      # when /boot is ro, we need to use transactional update to be able to
+      # rebuild initrd. In the end tu script below is used, but needs sauce
+      # around
+      if Package.IsTransactionalSystem
+        return update_initrd_with("transactional-update --continue kdump")
+      end
+
       # For CaaSP we need an explicit initrd rebuild before the
       # first boot, when the root filesystem becomes read only.
       rebuild_cmd = "/usr/sbin/tu-rebuild-kdump-initrd"

--- a/test/kdump_test.rb
+++ b/test/kdump_test.rb
@@ -1010,4 +1010,17 @@ describe Yast::Kdump do
       end
     end
   end
+
+  describe ".update_initrd" do
+    before do
+      allow(Yast::Package).to receive(:IsTransactionalSystem).and_return(false)
+    end
+
+    it "runs transactional-update kdump on transactional systems" do
+      allow(Yast::Package).to receive(:IsTransactionalSystem).and_return(true)
+      expect(subject).to receive(:update_initrd_with).with("transactional-update --continue kdump").and_return(true)
+
+      subject.update_initrd
+    end
+  end
 end


### PR DESCRIPTION
## Problem

Kdump failing on transactional system to rebuild initrd as /boot is read only.


## Solution

Call specific transactional-update calls and avoid direct modification of that content.


## Testing

- *Tested manually*


## Screenshots

*If the fix affects the UI attach some screenshots here.*

