### PR TITLE
Returned incorrectly removed replacepoint

### DIFF
--- a/package/yast2-kdump.changes
+++ b/package/yast2-kdump.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Sep 20 08:23:03 UTC 2022 - Michal Filka <mfilka@suse.com>
+
+- bsc#1202575
+  - fixed internal error caused by bug in UI in 4.5.3
+- 4.5.5
+
+-------------------------------------------------------------------
 Mon Sep 12 08:24:53 UTC 2022 - Josef Reidinger <jreidinger@suse.com>
 
 - Allow kdump to run on transactional systems (bsc#1128853)

--- a/package/yast2-kdump.spec
+++ b/package/yast2-kdump.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-kdump
-Version:        4.5.4
+Version:        4.5.5
 Release:        0
 Summary:        Configuration of kdump
 License:        GPL-2.0-only

--- a/src/include/kdump/dialogs.rb
+++ b/src/include/kdump/dialogs.rb
@@ -575,6 +575,7 @@ module Yast
             )
           ),
           VSpacing(1),
+          Left(ReplacePoint(Id("allocated_low_memory_rp"), low_memory_widget)),
           *high_widgets
         )
       )


### PR DESCRIPTION
## Problem

[bsc#1202575](https://bugzilla.suse.com/show_bug.cgi?id=1202575)

ReplacePoint for allocated_low_memory_rp was removed in https://github.com/yast/yast-kdump/pull/123

## Solution

Put the replace point back to work
