### PR TITLE
add support for fadump keys in kdumptool calibrate

### DIFF
--- a/package/yast2-kdump.changes
+++ b/package/yast2-kdump.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Fri Dec  9 09:53:31 UTC 2022 - Josef Reidinger <jreidinger@suse.com>
+
+- Support fadump values in output of kdumptools calibrate
+  (jsc#PED-1927)
+- drop support for older kdumptools
+- remove limits when kdumptools calibrate failed to allow user
+  enter anything
+- 4.5.7
+
+-------------------------------------------------------------------
 Wed Dec  7 17:14:38 UTC 2022 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Changed default of KDUMP_AUTO_RESIZE to "no" as documented in

--- a/package/yast2-kdump.spec
+++ b/package/yast2-kdump.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-kdump
-Version:        4.5.6
+Version:        4.5.7
 Release:        0
 Summary:        Configuration of kdump
 License:        GPL-2.0-only

--- a/src/include/kdump/dialogs.rb
+++ b/src/include/kdump/dialogs.rb
@@ -415,7 +415,7 @@ module Yast
           "widget_names"    => [
             "DisBackButton",
             "EnableDisalbeKdump",
-            (Kdump.system.supports_fadump? ? "FADump" : ""),
+            (Kdump.fadump_supported? ? "FADump" : ""),
             "KdumpMemory"
           ]
         },

--- a/src/include/kdump/dialogs.rb
+++ b/src/include/kdump/dialogs.rb
@@ -575,7 +575,8 @@ module Yast
             )
           ),
           VSpacing(1),
-          Left(ReplacePoint(Id("allocated_low_memory_rp"), low_memory_widget)),
+          Left(ReplacePoint(Id("allocated_low_memory_rp"),
+            low_memory_widget(fadump: Kdump.using_fadump?))),
           *high_widgets
         )
       )
@@ -614,9 +615,10 @@ module Yast
 
     # Returns the low memory widget
     #
-    # @param value [Integer] Current value
+    # @param value [Integer] Current value or default if nil passed
+    # @fadump fadump [Boolean] whener use low mem limits or fadump one
     # @return [Yast::Term] Low memory widget
-    def low_memory_widget(value = nil)
+    def low_memory_widget(value: nil, fadump: false)
       low_label = if Kdump.high_memory_supported?
         _("Kdump &Low Memory [MiB]")
       else
@@ -624,23 +626,26 @@ module Yast
       end
 
       limits = Kdump.memory_limits
-      current = (limits[:min_low]..limits[:max_low]).cover?(value) ? value : limits[:default_low]
+      min_limit = fadump ? limits[:min_fadump] : limits[:min_low]
+      max_limit = fadump ? limits[:max_fadump] : limits[:max_low]
+      default = fadump ? limits[:default_fadump] : limits[:default_low]
+      current = (min_limit..max_limit).cover?(value) ? value : default
 
       VBox(
         IntField(
           Id("allocated_low_memory"),
           Opt(:notify),
           low_label,
-          limits[:min_low],
-          limits[:max_low],
+          min_limit,
+          max_limit,
           current
         ),
         Label(
           # TRANSLATORS: %{min}, %{max}, %{default} are variable names which must not be translated.
           format(_("(min: %{min}; max: %{max}; suggested: %{default})"),
-            min:     limits[:min_low],
-            max:     limits[:max_low],
-            default: limits[:default_low])
+            min:     min_limit,
+            max:     max_limit,
+            default: default)
         )
       )
     end

--- a/src/include/kdump/uifunctions.rb
+++ b/src/include/kdump/uifunctions.rb
@@ -1435,7 +1435,7 @@ module Yast
 
     # Initializes FADump settings in UI
     def InitFADump(_key)
-      if Kdump.supports_fadump? && UI.WidgetExists(Id("FADump"))
+      if Kdump.fadump_supported? && UI.WidgetExists(Id("FADump"))
         UI.ReplaceWidget(
           Id("FADump"),
           VBox(

--- a/src/include/kdump/uifunctions.rb
+++ b/src/include/kdump/uifunctions.rb
@@ -1435,7 +1435,7 @@ module Yast
 
     # Initializes FADump settings in UI
     def InitFADump(_key)
-      if Kdump.system.supports_fadump? && UI.WidgetExists(Id("FADump"))
+      if Kdump.supports_fadump? && UI.WidgetExists(Id("FADump"))
         UI.ReplaceWidget(
           Id("FADump"),
           VBox(
@@ -1468,15 +1468,16 @@ module Yast
       UI.ChangeWidget(Id(:auto_resize), :Enabled, !use_fadump_value)
 
       update_usable_memory
-      refresh_kdump_memory
+      refresh_kdump_memory(use_fadump_value)
 
       nil
     end
 
-    def refresh_kdump_memory
+    def refresh_kdump_memory(fadump)
       widget_id = Id("allocated_low_memory")
       value = UI.QueryWidget(widget_id, :Value)
-      UI.ReplaceWidget(Id("allocated_low_memory_rp"), low_memory_widget(value))
+      UI.ReplaceWidget(Id("allocated_low_memory_rp"),
+        low_memory_widget(value: value, fadump: fadump))
     end
 
     # Function initializes option

--- a/src/lib/kdump/clients/kdump.rb
+++ b/src/lib/kdump/clients/kdump.rb
@@ -351,7 +351,7 @@ module Yast
         }
       }
 
-      if Kdump.system.supports_fadump?
+      if Kdump.fadump_supported?
         @cmdline_description["actions"]["fadump"] = {
           "handler" => fun_ref(method(:cmd_handle_fadump), "boolean (map)"),
           # TRANSLATORS: CommandLine help
@@ -718,7 +718,7 @@ module Yast
 
       CommandLine.Print("")
 
-      if Kdump.system.supports_fadump?
+      if Kdump.fadump_supported?
         show_fadump_status
         CommandLine.Print("")
       end

--- a/src/lib/kdump/kdump_calibrator.rb
+++ b/src/lib/kdump/kdump_calibrator.rb
@@ -162,8 +162,9 @@ module Yast
     def run_kdumptool
       out = Yast::SCR.Execute(Yast::Path.new(".target.bash_output"), kdumptool_cmd)
       if out["exit"].zero?
-        # ensure that fadump is set to unsupported as fadump can be missing in output
-        # and it means fadump not supported ( as oppose to high mem which is always in output)
+        # If fadump is missing from output, it means it isn't supported (unlike
+        # high mem, which is always in output). Thus, let's set fadump related
+        # values to zero before parsing the kdumptool output
         @max_fadump = @min_fadump = @default_fadump = 0
         proposal = parse(out["stdout"])
         # Populate @min_low, @max_low, @total_memory, etc.

--- a/src/modules/Kdump.rb
+++ b/src/modules/Kdump.rb
@@ -419,10 +419,7 @@ module Yast
 
       return true unless using_fadump_changed?
 
-      # See FATE#315780
-      # See https://www.suse.com/support/kb/doc.php?id=7012786
-      # FIXME what about dracut?
-      update_command = (using_fadump? ? "/usr/sbin/mkdumprd -f" : "/sbin/mkinitrd")
+      update_command = "/usr/sbin/mkdumprd -f"
       update_initrd_with(update_command)
     end
 

--- a/src/modules/Kdump.rb
+++ b/src/modules/Kdump.rb
@@ -344,12 +344,10 @@ module Yast
     # jsc#SLE-21644 for more information.
     #
     # @return [Hash] The hash contains the following keys: :min_low, :max_low,
-    #   :default_low, :min_high, :max_high, :default_high
+    #   :default_low, :min_high, :max_high, :default_high, :min_fadump,
+    #    :max_fadump, :default_fadump
     def memory_limits
-      limits = calibrator.memory_limits
-      return limits unless using_fadump?
-
-      limits.merge(min_low: 0, max_low: total_memory)
+      calibrator.memory_limits
     end
 
     # Propose reserved/allocated memory
@@ -1022,7 +1020,7 @@ module Yast
     # @return [Boolean] whether successfully set
     def use_fadump(new_value)
       # Trying to use fadump on unsupported hardware
-      if !system.supports_fadump? && new_value
+      if !supports_fadump? && new_value
         Builtins.y2milestone("FADump is not supported on this hardware")
         Report.Error(_("Cannot use Firmware-assisted dump.\nIt is not supported on this hardware."))
         return false
@@ -1052,6 +1050,13 @@ module Yast
     # @return [Boolean] is supported
     def high_memory_supported?
       calibrator.high_memory_supported?
+    end
+
+    # Returns whether usage of fadump is supported by the current system
+    #
+    # @return [Boolean] is supported
+    def fadump_supported?
+      calibrator.fadump_supported?
     end
 
     publish :function => :GetModified, :type => "boolean ()"
@@ -1229,7 +1234,7 @@ module Yast
     end
 
     def write_fadump_boot_param
-      if system.supports_fadump?
+      if supports_fadump?
         # If fdump is selected and we want to enable kdump
         value = "on" if using_fadump? && @add_crashkernel_param
         Bootloader.modify_kernel_params(:common, :recovery, "fadump" => value)

--- a/src/modules/Kdump.rb
+++ b/src/modules/Kdump.rb
@@ -1017,7 +1017,7 @@ module Yast
     # @return [Boolean] whether successfully set
     def use_fadump(new_value)
       # Trying to use fadump on unsupported hardware
-      if !supports_fadump? && new_value
+      if !fadump_supported? && new_value
         Builtins.y2milestone("FADump is not supported on this hardware")
         Report.Error(_("Cannot use Firmware-assisted dump.\nIt is not supported on this hardware."))
         return false
@@ -1231,7 +1231,7 @@ module Yast
     end
 
     def write_fadump_boot_param
-      if supports_fadump?
+      if fadump_supported?
         # If fdump is selected and we want to enable kdump
         value = "on" if using_fadump? && @add_crashkernel_param
         Bootloader.modify_kernel_params(:common, :recovery, "fadump" => value)

--- a/test/fadump_test.rb
+++ b/test/fadump_test.rb
@@ -6,7 +6,7 @@ Yast.import "Kdump"
 
 describe "#use_fadump" do
   before do
-    allow(Yast::Kdump.system).to receive(:supports_fadump?).and_return(supported)
+    allow(Yast::Kdump).to receive(:fadump_supported?).and_return(supported)
   end
 
   context "if fadump is supported on this architecture" do
@@ -37,7 +37,7 @@ end
 
 describe "#using_fadump?" do
   it "returns that fadump is in use if previously set" do
-    allow(Yast::Kdump.system).to receive(:supports_fadump?).and_return(true)
+    allow(Yast::Kdump).to receive(:fadump_supported?).and_return(true)
 
     Yast::Kdump.use_fadump(true)
     expect(Yast::Kdump.using_fadump?).to eq(true)
@@ -55,7 +55,7 @@ describe "#using_fadump_changed?" do
   end
 
   it "returns true if use_fadump changed" do
-    allow(Yast::Kdump.system).to receive(:supports_fadump?).and_return(true)
+    allow(Yast::Kdump).to receive(:fadump_supported?).and_return(true)
     Yast::Kdump.ReadKdumpSettings
 
     original_value = Yast::Kdump.using_fadump?

--- a/test/kdump_test.rb
+++ b/test/kdump_test.rb
@@ -429,7 +429,7 @@ describe Yast::Kdump do
   describe ".WriteKdumpBootParameter" do
     before do
       # FIXME: current tests do not cover fadump (ppc64 specific)
-      allow(Yast::Kdump.system).to receive(:supports_fadump?).and_return false
+      allow(Yast::Kdump).to receive(:fadump_supported?).and_return false
     end
 
     context "during autoinstallation" do

--- a/test/kdump_test.rb
+++ b/test/kdump_test.rb
@@ -963,12 +963,15 @@ describe Yast::Kdump do
   describe ".memory_limits" do
     let(:limits) do
       {
-        min_low:      72,
-        max_low:      3154,
-        default_low:  72,
-        min_high:     0,
-        max_high:     4247,
-        default_high: 323
+        min_low:        72,
+        max_low:        3154,
+        default_low:    72,
+        min_high:       0,
+        max_high:       4247,
+        default_high:   323,
+        min_fadump:     0,
+        max_fadump:     8096,
+        default_fadump: 512
       }
     end
 
@@ -989,25 +992,16 @@ describe Yast::Kdump do
 
     it "returns a hash containing the memory limits from the calibrator" do
       expect(subject.memory_limits).to eq(
-        min_low:      72,
-        max_low:      3154,
-        default_low:  72,
-        min_high:     0,
-        max_high:     4247,
-        default_high: 323
+        min_low:        72,
+        max_low:        3154,
+        default_low:    72,
+        min_high:       0,
+        max_high:       4247,
+        default_high:   323,
+        min_fadump:     0,
+        max_fadump:     8096,
+        default_fadump: 512
       )
-    end
-
-    context "when fadump is enabled" do
-      let(:fadump?) { true }
-
-      it "returns the total memory as limit :max_low limit" do
-        expect(subject.memory_limits[:max_low]).to eq(16334)
-      end
-
-      it "returns :min_low as 0" do
-        expect(subject.memory_limits[:min_low]).to eq(0)
-      end
     end
   end
 

--- a/test/lib/kdump/kdump_calibrator_test.rb
+++ b/test/lib/kdump/kdump_calibrator_test.rb
@@ -13,7 +13,6 @@ describe Yast::KdumpCalibrator do
                 "High: 2048\nMinHigh: 1024\nMaxHigh: 4096\n"\
                 "Fadump: 0\nMinFadump: 0\nMaxFadump: 0\nTotal: 16079\n"
   }.freeze
-  KDUMPTOOL_OLD = { "exit" => 0, "stdout" => "64\n" }.freeze
   KDUMPTOOL_ERROR = { "exit" => 1, "stdout" => "" }.freeze
 
   let(:configfile) { "/var/lib/YaST2/kdump.conf" }
@@ -41,8 +40,8 @@ describe Yast::KdumpCalibrator do
       end
     end
 
-    context "when kdumptool fails or uses the old format" do
-      let(:kdumptool_output) { KDUMPTOOL_OLD }
+    context "when kdumptool fails" do
+      let(:kdumptool_output) { KDUMPTOOL_ERROR }
 
       it "returns total memory as reported by SCR" do
         expect(subject.total_memory).to eq(4096)
@@ -57,19 +56,11 @@ describe Yast::KdumpCalibrator do
       end
     end
 
-    context "when kdumptool uses the old format" do
-      let(:kdumptool_output) { KDUMPTOOL_OLD }
-
-      it "returns the value found by kdumptool" do
-        expect(subject.min_low).to eq(64)
-      end
-    end
-
     context "when kdumptool does not succeed" do
       let(:kdumptool_output) { KDUMPTOOL_ERROR }
 
-      it "returns 72" do
-        expect(subject.min_low).to eq(72)
+      it "returns 0" do
+        expect(subject.min_low).to eq(0)
       end
     end
   end
@@ -81,19 +72,11 @@ describe Yast::KdumpCalibrator do
       end
     end
 
-    context "when kdumptool uses the old format" do
-      let(:kdumptool_output) { KDUMPTOOL_OLD }
-
-      it "returns the value found by kdumptool" do
-        expect(subject.default_low).to eq(64)
-      end
-    end
-
     context "when kdumptool does not succeed" do
       let(:kdumptool_output) { KDUMPTOOL_ERROR }
 
-      it "returns the fallback minimal margin" do
-        expect(subject.default_low).to eq(72)
+      it "returns 0" do
+        expect(subject.default_low).to eq(0)
       end
     end
   end
@@ -105,36 +88,16 @@ describe Yast::KdumpCalibrator do
       end
     end
 
-    context "when kdumptool fails or uses the old format" do
-      let(:kdumptool_output) { KDUMPTOOL_OLD }
+    context "when kdumptool fails" do
+      let(:kdumptool_output) { KDUMPTOOL_ERROR }
+      let(:total_memory) { 4096 }
 
       before do
         allow(subject).to receive(:total_memory).and_return(total_memory)
       end
 
-      context "when high memory is supported" do
-        let(:total_memory) { 4096 }
-
-        it "returns 896" do
-          expect(subject.max_low).to eq(896)
-        end
-      end
-
-      context "when high memory is not supported" do
-        let(:total_memory) { 4096 }
-        let(:x86_64) { false }
-
-        it "returns system memory" do
-          expect(subject.max_low).to eq(total_memory)
-        end
-      end
-
-      context "when high memory is supported but the available memory is small" do
-        let(:total_memory) { 784 }
-
-        it "returns system memory" do
-          expect(subject.max_low).to eq(total_memory)
-        end
+      it "returns total_memory" do
+        expect(subject.max_low).to eq(4096)
       end
     end
   end
@@ -145,14 +108,6 @@ describe Yast::KdumpCalibrator do
     context "when kdumptool succeeds" do
       it "returns the value found by kdumptool" do
         expect(subject.min_high).to eq(1024)
-      end
-    end
-
-    context "when kdumptool uses the old format" do
-      let(:kdumptool_output) { KDUMPTOOL_OLD }
-
-      it "returns 0" do
-        expect(subject.min_high).to eq(0)
       end
     end
 
@@ -171,14 +126,6 @@ describe Yast::KdumpCalibrator do
     context "when kdumptool succeeds" do
       it "returns the value found by kdumptool" do
         expect(subject.default_high).to eq(2048)
-      end
-    end
-
-    context "when kdumptool uses the old format" do
-      let(:kdumptool_output) { KDUMPTOOL_OLD }
-
-      it "returns 0 (the minimum fallback)" do
-        expect(subject.default_high).to eq(0)
       end
     end
 
@@ -204,32 +151,10 @@ describe Yast::KdumpCalibrator do
       context "when high memory is supported" do
         let(:x86_64) { true }
 
-        it "returns total_memory - 896" do
+        it "returns total_memory" do
           allow(subject).to receive(:total_memory).and_return(4096)
 
-          expect(subject.max_high).to eq(3200)
-        end
-      end
-
-      context "when high memory is not supported" do
-        let(:x86_64) { false }
-
-        it "returns 0" do
-          expect(subject.max_high).to eq(0)
-        end
-      end
-    end
-
-    context "when kdumptool uses the old format" do
-      let(:kdumptool_output) { KDUMPTOOL_OLD }
-
-      context "when high memory is supported" do
-        let(:x86_64) { true }
-
-        it "returns total_memory - 896" do
-          allow(subject).to receive(:total_memory).and_return(4096)
-
-          expect(subject.max_high).to eq(3200)
+          expect(subject.max_high).to eq(4096)
         end
       end
 
@@ -285,24 +210,6 @@ describe Yast::KdumpCalibrator do
         end
       end
     end
-
-    context "when kdumptool uses the old format" do
-      let(:kdumptool_output) { KDUMPTOOL_OLD }
-
-      context "when architecture is x86_64" do
-        it "returns true" do
-          expect(supported).to eq(true)
-        end
-      end
-
-      context "when architecture is not x86_64" do
-        let(:x86_64) { false }
-
-        it "returns false" do
-          expect(supported).to eq(false)
-        end
-      end
-    end
   end
 
   describe "#min_fadump" do
@@ -318,14 +225,6 @@ describe Yast::KdumpCalibrator do
 
       it "returns the value found by kdumptool" do
         expect(subject.min_fadump).to eq(128)
-      end
-    end
-
-    context "when kdumptool uses the old format" do
-      let(:kdumptool_output) { KDUMPTOOL_OLD }
-
-      it "returns 0" do
-        expect(subject.min_fadump).to eq(0)
       end
     end
 
@@ -351,14 +250,6 @@ describe Yast::KdumpCalibrator do
 
       it "returns the value found by kdumptool" do
         expect(subject.default_fadump).to eq(256)
-      end
-    end
-
-    context "when kdumptool uses the old format" do
-      let(:kdumptool_output) { KDUMPTOOL_OLD }
-
-      it "returns 0 (the minimum fallback)" do
-        expect(subject.default_fadump).to eq(0)
       end
     end
 
@@ -408,28 +299,6 @@ describe Yast::KdumpCalibrator do
         end
       end
     end
-
-    context "when kdumptool uses the old format" do
-      let(:kdumptool_output) { KDUMPTOOL_OLD }
-
-      context "when fadump memory is supported" do
-        let(:ppc64) { true }
-
-        it "returns total_memory" do
-          allow(subject).to receive(:total_memory).and_return(4096)
-
-          expect(subject.max_fadump).to eq(4096)
-        end
-      end
-
-      context "when fadump memory is not supported" do
-        let(:ppc64) { false }
-
-        it "returns 0" do
-          expect(subject.max_fadump).to eq(0)
-        end
-      end
-    end
   end
 
   describe "#fadump_supported?" do
@@ -460,26 +329,6 @@ describe Yast::KdumpCalibrator do
 
     context "when kdumptool fails" do
       let(:kdumptool_output) { KDUMPTOOL_ERROR }
-
-      context "when architecture is ppc64" do
-        let(:ppc64) { true }
-
-        it "returns true" do
-          expect(supported).to eq(true)
-        end
-      end
-
-      context "when architecture is not ppc64" do
-        let(:ppc64) { false }
-
-        it "returns false" do
-          expect(supported).to eq(false)
-        end
-      end
-    end
-
-    context "when kdumptool uses the old format" do
-      let(:kdumptool_output) { KDUMPTOOL_OLD }
 
       context "when architecture is ppc64" do
         let(:ppc64) { true }

--- a/test/lib/kdump/kdump_calibrator_test.rb
+++ b/test/lib/kdump/kdump_calibrator_test.rb
@@ -10,17 +10,20 @@ describe Yast::KdumpCalibrator do
   KDUMPTOOL_OK = {
     "exit"   => 0,
     "stdout" => "Low: 108\nMinLow: 32\nMaxLow: 712\n"\
-                "High: 2048\nMinHigh: 1024\nMaxHigh: 4096\nTotal: 16079\n"
+                "High: 2048\nMinHigh: 1024\nMaxHigh: 4096\n"\
+                "Fadump: 0\nMinFadump: 0\nMaxFadump: 0\nTotal: 16079\n"
   }.freeze
   KDUMPTOOL_OLD = { "exit" => 0, "stdout" => "64\n" }.freeze
   KDUMPTOOL_ERROR = { "exit" => 1, "stdout" => "" }.freeze
 
   let(:configfile) { "/var/lib/YaST2/kdump.conf" }
   let(:x86_64) { true }
+  let(:ppc64) { false }
   let(:kdumptool_output) { KDUMPTOOL_OK }
 
   before do
     allow(Yast::Arch).to receive(:x86_64).and_return(x86_64)
+    allow(Yast::Arch).to receive(:ppc64).and_return(ppc64)
     allow(Yast::SCR).to receive(:Execute)
       .with(Yast::Path.new(".target.bash_output"), anything).and_return(kdumptool_output)
     allow(Yast::SCR).to receive(:Read).with(path(".probe.memory"))
@@ -94,6 +97,7 @@ describe Yast::KdumpCalibrator do
       end
     end
   end
+
   context "#max_low" do
     context "when kdumptool succeeds" do
       it "returns the value found in kdumptool" do
@@ -293,6 +297,200 @@ describe Yast::KdumpCalibrator do
 
       context "when architecture is not x86_64" do
         let(:x86_64) { false }
+
+        it "returns false" do
+          expect(supported).to eq(false)
+        end
+      end
+    end
+  end
+
+  describe "#min_fadump" do
+    context "when kdumptool succeeds" do
+      let(:kdumptool_output) do
+        {
+          "exit"   => 0,
+          "stdout" => "Low: 108\nMinLow: 32\nMaxLow: 712\n"\
+                      "High: 2048\nMinHigh: 1024\nMaxHigh: 4096\n"\
+                      "Fadump: 256\nMinFadump: 128\nMaxFadump: 8192\nTotal: 16079\n"
+        }
+      end
+
+      it "returns the value found by kdumptool" do
+        expect(subject.min_fadump).to eq(128)
+      end
+    end
+
+    context "when kdumptool uses the old format" do
+      let(:kdumptool_output) { KDUMPTOOL_OLD }
+
+      it "returns 0" do
+        expect(subject.min_fadump).to eq(0)
+      end
+    end
+
+    context "when kdumptool fails" do
+      let(:kdumptool_output) { KDUMPTOOL_ERROR }
+
+      it "returns 0" do
+        expect(subject.min_fadump).to eq(0)
+      end
+    end
+  end
+
+  describe "#default_fadump" do
+    context "when kdumptool succeeds" do
+      let(:kdumptool_output) do
+        {
+          "exit"   => 0,
+          "stdout" => "Low: 108\nMinLow: 32\nMaxLow: 712\n"\
+                      "High: 2048\nMinHigh: 1024\nMaxHigh: 4096\n"\
+                      "Fadump: 256\nMinFadump: 128\nMaxFadump: 8192\nTotal: 16079\n"
+        }
+      end
+
+      it "returns the value found by kdumptool" do
+        expect(subject.default_fadump).to eq(256)
+      end
+    end
+
+    context "when kdumptool uses the old format" do
+      let(:kdumptool_output) { KDUMPTOOL_OLD }
+
+      it "returns 0 (the minimum fallback)" do
+        expect(subject.default_fadump).to eq(0)
+      end
+    end
+
+    context "when kdumptool fails" do
+      let(:kdumptool_output) { KDUMPTOOL_ERROR }
+
+      it "returns 0 (the minimum fallback)" do
+        expect(subject.default_fadump).to eq(0)
+      end
+    end
+  end
+
+  describe "#max_fadump" do
+    context "when kdumptool succeeds" do
+      let(:kdumptool_output) do
+        {
+          "exit"   => 0,
+          "stdout" => "Low: 108\nMinLow: 32\nMaxLow: 712\n"\
+                      "High: 2048\nMinHigh: 1024\nMaxHigh: 4096\n"\
+                      "Fadump: 256\nMinFadump: 128\nMaxFadump: 8192\nTotal: 16079\n"
+        }
+      end
+
+      it "returns the value found by kdumptool" do
+        expect(subject.max_fadump).to eq(8192)
+      end
+    end
+
+    context "when kdumptool fails" do
+      let(:kdumptool_output) { KDUMPTOOL_ERROR }
+
+      context "when fadump memory is supported" do
+        let(:ppc64) { true }
+
+        it "returns total_memory" do
+          allow(subject).to receive(:total_memory).and_return(4096)
+
+          expect(subject.max_fadump).to eq(4096)
+        end
+      end
+
+      context "when fadump memory is not supported" do
+        let(:ppc64) { false }
+
+        it "returns 0" do
+          expect(subject.max_fadump).to eq(0)
+        end
+      end
+    end
+
+    context "when kdumptool uses the old format" do
+      let(:kdumptool_output) { KDUMPTOOL_OLD }
+
+      context "when fadump memory is supported" do
+        let(:ppc64) { true }
+
+        it "returns total_memory" do
+          allow(subject).to receive(:total_memory).and_return(4096)
+
+          expect(subject.max_fadump).to eq(4096)
+        end
+      end
+
+      context "when fadump memory is not supported" do
+        let(:ppc64) { false }
+
+        it "returns 0" do
+          expect(subject.max_fadump).to eq(0)
+        end
+      end
+    end
+  end
+
+  describe "#fadump_supported?" do
+    subject(:supported) { described_class.new(configfile).fadump_supported? }
+
+    context "when kdumptool succeeds" do
+      context "if kdumptool allows fadump memory" do
+        let(:kdumptool_output) do
+          {
+            "exit"   => 0,
+            "stdout" => "Low: 108\nMinLow: 32\nMaxLow: 712\n"\
+                        "High: 2048\nMinHigh: 1024\nMaxHigh: 4096\n"\
+                        "Fadump: 256\nMinFadump: 128\nMaxFadump: 8192\nTotal: 16079\n"
+          }
+        end
+
+        it "returns true" do
+          expect(supported).to eq(true)
+        end
+      end
+
+      context "if kdumptool returns 0 for fadump memory" do
+        it "returns false" do
+          expect(supported).to eq(false)
+        end
+      end
+    end
+
+    context "when kdumptool fails" do
+      let(:kdumptool_output) { KDUMPTOOL_ERROR }
+
+      context "when architecture is ppc64" do
+        let(:ppc64) { true }
+
+        it "returns true" do
+          expect(supported).to eq(true)
+        end
+      end
+
+      context "when architecture is not ppc64" do
+        let(:ppc64) { false }
+
+        it "returns false" do
+          expect(supported).to eq(false)
+        end
+      end
+    end
+
+    context "when kdumptool uses the old format" do
+      let(:kdumptool_output) { KDUMPTOOL_OLD }
+
+      context "when architecture is ppc64" do
+        let(:ppc64) { true }
+
+        it "returns true" do
+          expect(supported).to eq(true)
+        end
+      end
+
+      context "when architecture is not ppc64" do
+        let(:ppc64) { false }
 
         it "returns false" do
           expect(supported).to eq(false)


### PR DESCRIPTION
## Problem

`kdumptool calibrate` newly output also fadump related keys. It is not used by yast2-kdump

- https://jira.suse.com/browse/PED-1927
- https://trello.com/c/b8HlgvxX/3236-jscped-1927-support-fadump-values-from-kdump-calibrate


## Solution

* Implement recognition of that new values and use it instead of hardcoded ones
* Adapt the code as agreed in Jira by
   - dropping support for old format of kdumptools
   - simplifying the behavior when kdumptools failed to allow user enter anything
   - handling when fadump is missing in output of kdumptools


## Testing

- *Added a new unit test*
- *Tested manually*