### PR TITLE
Change Default for KDUMP_AUTO_RESIZE to "no"

### DIFF
--- a/package/yast2-kdump.changes
+++ b/package/yast2-kdump.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Dec  7 17:14:38 UTC 2022 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Changed default of KDUMP_AUTO_RESIZE to "no" as documented in
+  https://github.com/openSUSE/kdump/blob/SLE-15-SP5/sysconfig.kdump.in#L57-L65
+  (bsc#1205816)
+- 4.5.6
+
+-------------------------------------------------------------------
 Tue Sep 20 08:23:03 UTC 2022 - Michal Filka <mfilka@suse.com>
 
 - bsc#1202575

--- a/package/yast2-kdump.spec
+++ b/package/yast2-kdump.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-kdump
-Version:        4.5.5
+Version:        4.5.6
 Release:        0
 Summary:        Configuration of kdump
 License:        GPL-2.0-only

--- a/src/modules/Kdump.rb
+++ b/src/modules/Kdump.rb
@@ -150,7 +150,7 @@ module Yast
         "KDUMP_CPUS"               => "",
         "KDUMP_COMMANDLINE"        => "",
         "KDUMP_COMMANDLINE_APPEND" => "",
-        "KDUMP_AUTO_RESIZE"        => "yes",
+        "KDUMP_AUTO_RESIZE"        => "no",
         "KEXEC_OPTIONS"            => "",
         "KDUMP_IMMEDIATE_REBOOT"   => "yes",
         "KDUMP_COPY_KERNEL"        => "yes",

--- a/test/kdump_test.rb
+++ b/test/kdump_test.rb
@@ -433,7 +433,7 @@ describe Yast::Kdump do
     end
 
     context "during autoinstallation" do
-      let(:bootloader_kernel_params) { ["2047M,high"] }
+      let(:bootloader_kernel_params) { ["73M,high"] }
       let(:bootloader_kernel_params_noauto) { ["73M,high"] }
       let(:bootloader_xen_kernel_params) { ["73M\\<4G"] }
 
@@ -547,7 +547,7 @@ describe Yast::Kdump do
     end
 
     context "during autoupgrade" do
-      let(:bootloader_kernel_params) { ["1968M,high"] }
+      let(:bootloader_kernel_params) { ["75M,high"] }
       let(:bootloader_kernel_params_noauto) { ["75M,high"] }
       let(:bootloader_xen_kernel_params) { ["75M\\<4G"] }
 
@@ -815,7 +815,7 @@ describe Yast::Kdump do
     end
 
     context "on a system with no low/high distinction" do
-      let(:bootloader_kernel_params) { ["650M"] }
+      let(:bootloader_kernel_params) { ["93M"] }
       let(:bootloader_xen_kernel_params) { ["93M\\<4G"] }
 
       before do


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1205816


## Problem

The new KDUMP_AUTO_RESIZE causes problems with Xen virtualization: Both subsystems have a race condition against each other with memory allocation, and the Xen guest finally throws a kernel panic.


## Cause

The deeper cause must be left to the kernel experts to discuss.

But one of the latest changes to yast-kdump switched that new feature on by default, and after a long discussion this turned out to be wrong:

https://github.com/openSUSE/kdump/blob/SLE-15-SP5/sysconfig.kdump.in#L57-L65

```
## Type:        yesno
## Default:     "no"
#
# When this option is set to yes, kdump tries to shrink the crash
# kernel reservation at boot.
#
# See also: kdump(6).
#
KDUMP_AUTO_RESIZE="no"
```


## Fix

Set the default to "no". That is what this PR does.


## Side Effect

The default crash kernel sizes now shrink dramatically.