### PR TITLE
bump properly version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Git Fix
       # fix the ownership to pass a git security check
@@ -52,7 +52,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Rubocop
       run: rake check:rubocop
@@ -69,7 +69,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Package Build
       run: yast-ci-ruby -o package
@@ -86,7 +86,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Yardoc
       run: rake check:doc
@@ -105,7 +105,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Perl Syntax
       run: yast-ci-ruby -o perl_syntax

--- a/package/yast2-kdump.changes
+++ b/package/yast2-kdump.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Nov 13 15:35:53 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
+
+- Bump properly version as old 4.6.1 contains removal of keys from
+  AY  that breaks old autoyast profile. So we fix it to just
+  deprecate it, but we need proper new version. (bsc#1217057)
+- 4.6.2
+
+-------------------------------------------------------------------
 Fri Jun 23 12:00:54 CEST 2023 - Jiri Bohac <jbohac@suse.cz>
 
 - adapt for version kdump versions 1.9+ (bsc#1212646)

--- a/package/yast2-kdump.spec
+++ b/package/yast2-kdump.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-kdump
-Version:        4.6.1
+Version:        4.6.2
 Release:        0
 Summary:        Configuration of kdump
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

Root of issue is at https://github.com/yast/yast-kdump/pull/136 which originally was same as 4.6.1 in TW, but in the  end we changed some AY keys removal and it was not same, but we do not bump properly version. Result is that it was never submitted to SP6.

link to jenkins job that show that new version with re-added rnc elements was never submitted to SP6 - https://ci.suse.de/job/yast-yast-kdump-SLE-15-SP6/2/console ( internal only )

## Solution

Bump version and also update dependency in yast2-schema.