### PR TITLE
update default for KDUMP_CPUS to 0

### DIFF
--- a/src/modules/Kdump.rb
+++ b/src/modules/Kdump.rb
@@ -147,7 +147,7 @@ module Yast
 
       @DEFAULT_CONFIG = {
         "KDUMP_KERNELVER"          => "",
-        "KDUMP_CPUS"               => "1",
+        "KDUMP_CPUS"               => "0",
         "KDUMP_COMMANDLINE"        => "",
         "KDUMP_COMMANDLINE_APPEND" => "",
         "KDUMP_AUTO_RESIZE"        => "false",


### PR DESCRIPTION
KDUMP_CPUS now defaults to 0, see kdump commit
60525b4afa680650c9c85b4dc26372b34481d908


## Problem

*Short description of the original problem.*

- *Bugzilla link*
- *openQA link*
- *Links to other related pull requests*


## Solution

*Short description of the fix.*


## Testing

- *Added a new unit test*
- *Tested manually*


## Screenshots

*If the fix affects the UI attach some screenshots here.*

