### PR TITLE
Don't Add Empty fadump="" Kernel Parameter [master]

### DIFF
--- a/package/yast2-kdump.changes
+++ b/package/yast2-kdump.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Sep 17 14:24:44 UTC 2024 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Don't write empty  fadump=""  kernel parameter (bsc#1230359)
+- 5.0.2
+
+-------------------------------------------------------------------
 Wed Jun 19 15:36:03 UTC 2024 - Stefan Schubert <schubi@suse.com>
 
 - Do not suggest Kdump if Systemd-Boot is used. Kdump is not stable

--- a/package/yast2-kdump.spec
+++ b/package/yast2-kdump.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-kdump
-Version:        5.0.1
+Version:        5.0.2
 Release:        0
 Summary:        Configuration of kdump
 License:        GPL-2.0-only

--- a/src/modules/Kdump.rb
+++ b/src/modules/Kdump.rb
@@ -1230,6 +1230,7 @@ module Yast
 
       # If fdump is selected and we want to enable kdump
       value = "on" if using_fadump? && @add_crashkernel_param
+      value ||= :missing
       Bootloader.modify_kernel_params(:common, :recovery, "fadump" => value)
       Bootloader.Write unless Yast::Stage.initial # do mass write in installation to speed up
     end


### PR DESCRIPTION
## Target Branch

**This  merges #142 / #141  to _master_ / _Factory_.**

## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1230359


## Trello


## Problem

On the PPC64 architecture, when _fadump_ (Firmware Assisted Dump) kernel dumps are supported, but the user chooses not to enable that in the YaST UI, the `fadump` kernel parameter is still added, albeit with an empty argument:

```
fadump=""
```

This does not really do any harm, but user scripts that check for this kernel parameter may be confused.


## Fix

Don't add this parameter if its argument is empty. If it's already there, but empty, remove it with the special `:missing` argument.

## Test

- Hacked up a (x86_64) TW VM: Moved away the original `kdumptool` and replaced it with a shell script that writes the values from https://bugzilla.suse.com/show_bug.cgi?id=1230359#c12 to stdout to mock fadump support.

- Manual test with `yast2 bootloader` and `yast2 kdump`.

<Details>

- Checked the original kernel parameters in `/etc/default/grub` and in `/boot/grub2/grub.cfg`
- Double-checked the kernel parameters with `yast2 bootloader`

- Started `yast2 kdump`:
  - Enabled kdump
  - Enabled fadump
  - Saved the configuration
- Checked the kernel parameters again in `/etc/default/grub` and in `/boot/grub2/grub.cfg`: There should now be an `fadump="on"` parameter.

- Started `yast2 kdump` again:
  - Enabled kdump
  - Disabled fadump
  - Saved the configuration
  - Checked the kernel parameters again in `/etc/default/grub` and in `/boot/grub2/grub.cfg`: There should now **not** an `fadump="` parameter.

- Edited `/etc/default/grub` and added an empty `fadump=` parameter
- Started `yast2 kdump` again:
  - Enabled kdump
  - Disabled fadump
  - Saved the configuration
  - Checked the kernel parameters again in `/etc/default/grub` and in `/boot/grub2/grub.cfg`: There should now **not** an `fadump="` parameter despite the manually added one.
</Details>


## Related PRs

- Original PR for SLE-15-SP6: #141 
- Merge PR to SLE-15-SP7: #142 
