### PR TITLE
Bad KDUMP_CPUS in  Default KDump Config [SLE-15-SP7]

### DIFF
--- a/package/yast2-kdump.changes
+++ b/package/yast2-kdump.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Feb 27 11:48:40 UTC 2025 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Applied patch from jbohac for bsc#1237754
+- 4.7.2
+
+-------------------------------------------------------------------
 Tue Sep 17 14:24:44 UTC 2024 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Don't write empty  fadump=""  kernel parameter (bsc#1230359)

--- a/package/yast2-kdump.spec
+++ b/package/yast2-kdump.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-kdump
-Version:        4.7.1
+Version:        4.7.2
 Release:        0
 Summary:        Configuration of kdump
 License:        GPL-2.0-only

--- a/src/modules/Kdump.rb
+++ b/src/modules/Kdump.rb
@@ -147,7 +147,7 @@ module Yast
 
       @DEFAULT_CONFIG = {
         "KDUMP_KERNELVER"          => "",
-        "KDUMP_CPUS"               => "1",
+        "KDUMP_CPUS"               => "0",
         "KDUMP_COMMANDLINE"        => "",
         "KDUMP_COMMANDLINE_APPEND" => "",
         "KDUMP_AUTO_RESIZE"        => "false",


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1237754


## Problem

The default value for `KDUMP_CPUS` turned out to cause problems.


## Fix

Better value for this `KDUMP_CPUS`. Patch kindly provided by @jiribohac.