### PR TITLE
Bad KDUMP_CPUS Value in Default KDump Config [master]

### DIFF
--- a/package/yast2-kdump.changes
+++ b/package/yast2-kdump.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Feb 27 11:48:40 UTC 2025 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Applied patch from jbohac for bsc#1237754, let KDUMP_CPUS=0
+- 5.0.3
+
+-------------------------------------------------------------------
 Tue Sep 17 14:24:44 UTC 2024 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Don't write empty  fadump=""  kernel parameter (bsc#1230359)

--- a/package/yast2-kdump.spec
+++ b/package/yast2-kdump.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-kdump
-Version:        5.0.2
+Version:        5.0.3
 Release:        0
 Summary:        Configuration of kdump
 License:        GPL-2.0-only

--- a/src/modules/Kdump.rb
+++ b/src/modules/Kdump.rb
@@ -142,7 +142,7 @@ module Yast
 
       @DEFAULT_CONFIG = {
         "KDUMP_KERNELVER"          => "",
-        "KDUMP_CPUS"               => "1",
+        "KDUMP_CPUS"               => "0",
         "KDUMP_COMMANDLINE"        => "",
         "KDUMP_COMMANDLINE_APPEND" => "",
         "KDUMP_AUTO_RESIZE"        => "false",


### PR DESCRIPTION
## Target Branch

This merges #144 to _master_.

## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1237754


## Problem

The default value for `KDUMP_CPUS` turned out to cause problems.


## Fix

Better value for this `KDUMP_CPUS`. Patch kindly provided by @jiribohac.