### PR TITLE
Change default value of KDUMP_CPUS to 32

### DIFF
--- a/src/modules/Kdump.rb
+++ b/src/modules/Kdump.rb
@@ -147,7 +147,7 @@ module Yast
 
       @DEFAULT_CONFIG = {
         "KDUMP_KERNELVER"          => "",
-        "KDUMP_CPUS"               => "0",
+        "KDUMP_CPUS"               => "32",
         "KDUMP_COMMANDLINE"        => "",
         "KDUMP_COMMANDLINE_APPEND" => "",
         "KDUMP_AUTO_RESIZE"        => "false",


### PR DESCRIPTION
Match the kdump default since v2.0.18,
(change described in
https://github.com/openSUSE/kdump/commit/95378d3924a5b669f283bd4726c4bcb4c99b708f) 
References: bsc#1240769, jsc#PED-9894, bsc#1237754, bsc#1239999


