### PR TITLE
Merge #146, #148 to Master

### DIFF
--- a/package/yast2-kdump.changes
+++ b/package/yast2-kdump.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Apr 15 17:27:11 UTC 2025 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Applied patch from jbohac for bsc#1240769, jsc#PED-9894,
+  bsc#1237754, bsc#1239999: KDUMP_CPUS=32
+- 5.0.4
+
+-------------------------------------------------------------------
 Thu Feb 27 11:48:40 UTC 2025 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Applied patch from jbohac for bsc#1237754, let KDUMP_CPUS=0

--- a/package/yast2-kdump.spec
+++ b/package/yast2-kdump.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-kdump
-Version:        5.0.3
+Version:        5.0.4
 Release:        0
 Summary:        Configuration of kdump
 License:        GPL-2.0-only

--- a/src/modules/Kdump.rb
+++ b/src/modules/Kdump.rb
@@ -142,7 +142,7 @@ module Yast
 
       @DEFAULT_CONFIG = {
         "KDUMP_KERNELVER"          => "",
-        "KDUMP_CPUS"               => "0",
+        "KDUMP_CPUS"               => "32",
         "KDUMP_COMMANDLINE"        => "",
         "KDUMP_COMMANDLINE_APPEND" => "",
         "KDUMP_AUTO_RESIZE"        => "false",


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1237754
https://bugzilla.suse.com/show_bug.cgi?id=1240769


## Target Branch

This merges #146 and #148 to _master_ / _Factory_.

This supersedes #147 to keep our merge chain intact.

## Problem + Fix

`KDUMP_CPUS=0` caused long delays on systems with very many (hundreds) of CPUs, so @jiribohac decided to use an upper limit of 32 again.

