### PR TITLE
Bootloader.Write will also be called while new installtion

### DIFF
--- a/package/yast2-kdump.changes
+++ b/package/yast2-kdump.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Fri Sep 19 13:05:39 UTC 2025 - Stefan Schubert <schubi@suse.de>
+
+- Calling Bootloader.Write even in the installation workflow
+  for every change in the bootloader settings.
+  (bsc#1249370, bsc#1226676, bsc#1226676)
+- Do not warn if systemd-boot will be used for bootloader.
+- 5.0.6
+
+-------------------------------------------------------------------
 Tue May 20 11:29:08 UTC 2025 - Stefan Schubert <schubi@suse.de>
 
 - Fixed testsuite (a follow up of jsc#PED-10703)

--- a/package/yast2-kdump.changes
+++ b/package/yast2-kdump.changes
@@ -3,7 +3,7 @@ Fri Sep 19 13:05:39 UTC 2025 - Stefan Schubert <schubi@suse.de>
 
 - Calling Bootloader.Write even in the installation workflow
   for every change in the bootloader settings.
-  (bsc#1249370, bsc#1226676, bsc#1226676)
+  (bsc#1249370, bsc#1226676)
 - Do not warn if systemd-boot will be used for bootloader.
 - 5.0.6
 

--- a/package/yast2-kdump.spec
+++ b/package/yast2-kdump.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-kdump
-Version:        5.0.5
+Version:        5.0.6
 Release:        0
 Summary:        Configuration of kdump
 License:        GPL-2.0-only

--- a/src/modules/Kdump.rb
+++ b/src/modules/Kdump.rb
@@ -682,7 +682,7 @@ module Yast
 
     def ProposeCrashkernelParam
       # proposing disabled kdump if product wants it (bsc#1071242)
-      elsif !ProductFeatures.GetBooleanFeature("globals", "enable_kdump")
+      if !ProductFeatures.GetBooleanFeature("globals", "enable_kdump")
         log.info "Kdump disabled in control file"
         false
       # proposing disabled kdump if PC has less than 1024MB RAM

--- a/src/modules/Kdump.rb
+++ b/src/modules/Kdump.rb
@@ -415,14 +415,14 @@ module Yast
       y2milestone("Running command: #{run_command}")
       ret = SCR.Execute(path(".target.bash"), run_command)
 
-#      if ret != 0
+      if ret != 0
         y2error("Error updating initrd, see #{update_logfile} or call #{update_command} manually")
         Report.Error(format(_(
           "Error updating initrd while calling '%{cmd}'.\n" \
           "See %{log} for details."
         ), :cmd => update_command, :log => update_logfile))
-#        return false
-#      end
+        return false
+      end
 
       true
     end
@@ -674,7 +674,7 @@ module Yast
       Progress.NextStage
 
       return false if Abort()
-
+Report.Error(_("HAlt."))
       true
     end
 

--- a/src/modules/Kdump.rb
+++ b/src/modules/Kdump.rb
@@ -497,11 +497,9 @@ module Yast
           Bootloader.modify_kernel_params(:common, :recovery, "crashkernel" => crash_values)
           Bootloader.modify_kernel_params(:xen_host, "crashkernel" => crash_xen_values)
           # do mass write in installation to speed up, so skip this one
-          unless Stage.initial
-            old_progress = Progress.set(false)
-            Bootloader.Write
-            Progress.set(old_progress)
-          end
+          old_progress = Progress.set(false)
+          Bootloader.Write
+          Progress.set(old_progress)
           Builtins.y2milestone(
             "[kdump] (WriteKdumpBootParameter) adding crashkernel options with values: %1",
             crash_values
@@ -519,11 +517,9 @@ module Yast
         if @crashkernel_param
           # delete crashkernel parameter from bootloader
           Bootloader.modify_kernel_params(:common, :xen_guest, :recovery, :xen_host, "crashkernel" => :missing)
-          unless Stage.initial
-            old_progress = Progress.set(false)
-            Bootloader.Write
-            Progress.set(old_progress)
-          end
+          old_progress = Progress.set(false)
+          Bootloader.Write
+          Progress.set(old_progress)
           reboot_needed = true
         end
         Service.Disable(KDUMP_SERVICE_NAME)

--- a/src/modules/Kdump.rb
+++ b/src/modules/Kdump.rb
@@ -492,6 +492,8 @@ module Yast
           Bootloader.modify_kernel_params(:xen_host, "crashkernel" => crash_xen_values)
           # do mass write in installation to speed up, so skip this one
           old_progress = Progress.set(false)
+          # Has also to be called while installation because Kdbump finish will be called
+          # after Bootloader finish. (bsc#1249370, bsc#1226676, bsc#1226676)
           Bootloader.Write
           Progress.set(old_progress)
           Builtins.y2milestone(
@@ -511,6 +513,8 @@ module Yast
           # delete crashkernel parameter from bootloader
           Bootloader.modify_kernel_params(:common, :xen_guest, :recovery, :xen_host, "crashkernel" => :missing)
           old_progress = Progress.set(false)
+          # Has also to be called while installation because Kdbump finish will be called
+          # after Bootloader finish. (bsc#1249370, bsc#1226676, bsc#1226676)
           Bootloader.Write
           Progress.set(old_progress)
           reboot_needed = true

--- a/src/modules/Kdump.rb
+++ b/src/modules/Kdump.rb
@@ -493,7 +493,7 @@ module Yast
           # do mass write in installation to speed up, so skip this one
           old_progress = Progress.set(false)
           # Has also to be called while installation because Kdbump finish will be called
-          # after Bootloader finish. (bsc#1249370, bsc#1226676, bsc#1226676)
+          # after Bootloader finish. (bsc#1249370, bsc#1226676)
           Bootloader.Write
           Progress.set(old_progress)
           Builtins.y2milestone(
@@ -514,7 +514,7 @@ module Yast
           Bootloader.modify_kernel_params(:common, :xen_guest, :recovery, :xen_host, "crashkernel" => :missing)
           old_progress = Progress.set(false)
           # Has also to be called while installation because Kdbump finish will be called
-          # after Bootloader finish. (bsc#1249370, bsc#1226676, bsc#1226676)
+          # after Bootloader finish. (bsc#1249370, bsc#1226676)
           Bootloader.Write
           Progress.set(old_progress)
           reboot_needed = true

--- a/src/modules/Kdump.rb
+++ b/src/modules/Kdump.rb
@@ -465,19 +465,15 @@ module Yast
       # Then, do the same for the crashkernel param
       #
       # If we need to add crashkernel param
-      Builtins.y2milestone("WriteKdumpBootParameter:1")
       if @add_crashkernel_param
-        Builtins.y2milestone("WriteKdumpBootParameter:2")        
         if Mode.autoinst || Mode.autoupgrade
           # Use the value(s) read by import
           crash_values = @crashkernel_param_values
           crash_xen_values = @crashkernel_xen_param_values
           # Always write the value
           skip_crash_values = false
-          Builtins.y2milestone("WriteKdumpBootParameter:3")          
         else
           # Calculate the param values based on @allocated_memory
-      Builtins.y2milestone("WriteKdumpBootParameter:4")          
           crash_values = crash_kernel_values
           crash_xen_values = crash_xen_kernel_values
           remove_offsets!(crash_values) if Mode.update
@@ -488,12 +484,10 @@ module Yast
         end
 
         if skip_crash_values
-          Builtins.y2milestone("WriteKdumpBootParameter:5")          
           # start kdump at boot
           Service.Enable(KDUMP_SERVICE_NAME)
           Service.Restart(KDUMP_SERVICE_NAME) if Service.active?(KDUMP_SERVICE_NAME)
         else
-          Builtins.y2milestone("WriteKdumpBootParameter:6")          
           Bootloader.modify_kernel_params(:common, :recovery, "crashkernel" => crash_values)
           Bootloader.modify_kernel_params(:xen_host, "crashkernel" => crash_xen_values)
           # do mass write in installation to speed up, so skip this one
@@ -512,7 +506,6 @@ module Yast
           Service.Enable(KDUMP_SERVICE_NAME)
         end
       else
-        Builtins.y2milestone("WriteKdumpBootParameter:7")        
         # If we don't need the param but it is there
         if @crashkernel_param
           # delete crashkernel parameter from bootloader
@@ -670,7 +663,7 @@ module Yast
       Progress.NextStage
 
       return false if Abort()
-Report.Error(_("HAlt."))
+
       true
     end
 

--- a/src/modules/Kdump.rb
+++ b/src/modules/Kdump.rb
@@ -415,14 +415,14 @@ module Yast
       y2milestone("Running command: #{run_command}")
       ret = SCR.Execute(path(".target.bash"), run_command)
 
-      if ret != 0
+#      if ret != 0
         y2error("Error updating initrd, see #{update_logfile} or call #{update_command} manually")
         Report.Error(format(_(
           "Error updating initrd while calling '%{cmd}'.\n" \
           "See %{log} for details."
         ), :cmd => update_command, :log => update_logfile))
-        return false
-      end
+#        return false
+#      end
 
       true
     end

--- a/src/modules/Kdump.rb
+++ b/src/modules/Kdump.rb
@@ -681,10 +681,6 @@ module Yast
     # @return [Boolean] the default proposed state
 
     def ProposeCrashkernelParam
-      # proposing disabled kdump because it does not work with systemd-boot together
-      if Bootloader.getLoaderType == "systemd-boot"
-        log.info("kdump disabled because systemd-boot is active.")
-        false
       # proposing disabled kdump if product wants it (bsc#1071242)
       elsif !ProductFeatures.GetBooleanFeature("globals", "enable_kdump")
         log.info "Kdump disabled in control file"
@@ -904,11 +900,6 @@ module Yast
           "Warning! There might not be enough free space to have kdump enabled. " \
           "%{required} required for saving a kernel dump, but only %{available} are available."
         ), required: String.FormatSizeWithPrecision(requested_space, 2, true), available: String.FormatSizeWithPrecision(free_space, 2, true))
-      end
-
-      if Bootloader.getLoaderType == "systemd-boot" && @add_crashkernel_param
-        warning_string += "<br>" unless warning_string.empty?
-        warning_string += _("Kdump will not be installed correctly if Systemd Boot is used.")
       end
 
       unless warning_string.empty?

--- a/src/modules/Kdump.rb
+++ b/src/modules/Kdump.rb
@@ -465,15 +465,19 @@ module Yast
       # Then, do the same for the crashkernel param
       #
       # If we need to add crashkernel param
+      Builtins.y2milestone("WriteKdumpBootParameter:1")
       if @add_crashkernel_param
+        Builtins.y2milestone("WriteKdumpBootParameter:2")        
         if Mode.autoinst || Mode.autoupgrade
           # Use the value(s) read by import
           crash_values = @crashkernel_param_values
           crash_xen_values = @crashkernel_xen_param_values
           # Always write the value
           skip_crash_values = false
+          Builtins.y2milestone("WriteKdumpBootParameter:3")          
         else
           # Calculate the param values based on @allocated_memory
+      Builtins.y2milestone("WriteKdumpBootParameter:4")          
           crash_values = crash_kernel_values
           crash_xen_values = crash_xen_kernel_values
           remove_offsets!(crash_values) if Mode.update
@@ -484,10 +488,12 @@ module Yast
         end
 
         if skip_crash_values
+          Builtins.y2milestone("WriteKdumpBootParameter:5")          
           # start kdump at boot
           Service.Enable(KDUMP_SERVICE_NAME)
           Service.Restart(KDUMP_SERVICE_NAME) if Service.active?(KDUMP_SERVICE_NAME)
         else
+          Builtins.y2milestone("WriteKdumpBootParameter:6")          
           Bootloader.modify_kernel_params(:common, :recovery, "crashkernel" => crash_values)
           Bootloader.modify_kernel_params(:xen_host, "crashkernel" => crash_xen_values)
           # do mass write in installation to speed up, so skip this one
@@ -508,6 +514,7 @@ module Yast
           Service.Enable(KDUMP_SERVICE_NAME)
         end
       else
+        Builtins.y2milestone("WriteKdumpBootParameter:7")        
         # If we don't need the param but it is there
         if @crashkernel_param
           # delete crashkernel parameter from bootloader


### PR DESCRIPTION
## Problem

We are calling bootloader finish before kdump finish:
https://github.com/yast/yast-installation/pull/1137
So, changes in bootloader settings will only be written if Bootloader.write will be called again.
This error has also happened whith systemd-boot, which is also fixes. So, the warning "not to use it"
has been removed too.

- bsc#1249370, bsc#1226676, bsc#1226676
- https://openqa.opensuse.org/tests/5294128/modules/installation/steps/45


## Solution

Calling Bootloader every time if the bootloader settings have been changed.


## Testing

- Tested manually


